### PR TITLE
sim-lib: Add event queue common structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bitcoin"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1 0.24.3",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+dependencies = [
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes 0.12.0",
+ "hex_lit",
+ "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +206,15 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "lightning"
+version = "0.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+dependencies = [
+ "bitcoin 0.29.2",
+]
 
 [[package]]
 name = "lock_api"
@@ -286,6 +352,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secp256k1"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
+ "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +445,8 @@ dependencies = [
 name = "sim-lib"
 version = "0.1.0"
 dependencies = [
+ "bitcoin 0.30.1",
+ "lightning",
  "serde",
  "serde_json",
 ]

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 serde = { version="1.0.183", features=["derive"] }
 serde_json = "1.0.104"
+bitcoin = { version = "0.30.1" }
+lightning = { version = "0.0.116" }

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::PaymentHash;
 
 // Phase 0: User input - see config.json
 
@@ -17,6 +19,33 @@ pub struct Config {
     nodes: Vec<NodeConnection>,
 }
 
-// Phase 2: Event Queue - TODO
+// Phase 2: Event Queue
+
+#[allow(dead_code)]
+enum PaymentError {}
+
+/// LightningNode represents the functionality that is required to execute events on a lightning node.
+trait LightningNode {
+    fn send_payment(&self, dest: PublicKey, amt_msat: u64) -> Result<PaymentHash, ()>;
+    fn track_payment(&self, hash: PaymentHash) -> Result<(), PaymentError>;
+}
+
+#[allow(dead_code)]
+enum NodeAction {
+    // Dispatch a payment of the specified amount to the public key provided.
+    SendPayment(PublicKey, u64),
+}
+
+#[allow(dead_code)]
+struct Event {
+    // The public key of the node executing this event.
+    source: PublicKey,
+
+    // Offset is the time offset from the beginning of execution that this event should be executed.
+    offset: u64,
+
+    // An action to be executed on the source node.
+    action: NodeAction,
+}
 
 // Phase 3: CSV output - TODO

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+// Phase 0: User input - see config.json
+
+// Phase 1: Parsed User Input
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeConnection {
     id: String,
@@ -13,17 +17,6 @@ pub struct Config {
     nodes: Vec<NodeConnection>,
 }
 
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+// Phase 2: Event Queue - TODO
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+// Phase 3: CSV output - TODO


### PR DESCRIPTION
Breaking things up into steps to allow us to work independently, the output at each phase feeds into the next one: 
* Phase 0: user input in config file (as specified in #2)
* Phase 1: parsed activity description + LN clients for each node 
* Phase 2:  generated queue of events (this PR)
* Phase 3: CSV file of results