### PR TITLE
Reworks LndNode so we persist NodeInfo within it

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -35,11 +35,10 @@ async fn main() -> anyhow::Result<()> {
     for node in nodes {
         let lnd = LndNode::new(node.address, node.macaroon, node.cert).await?;
 
-        let node_info = lnd.get_info().await?;
         log::info!(
             "Connected to {} - Node ID: {}",
-            node_info.alias,
-            node_info.pubkey
+            lnd.get_info().alias,
+            lnd.get_info().pubkey
         );
 
         clients.insert(node.id, Arc::new(Mutex::new(lnd)));


### PR DESCRIPTION
This modifies the LightningNode trait with respect to get_info. Now instead of implementing the get_info rpc command on LightningNode::get_info we set that as a getter to NodeInfo, and NodeInfo is built calling the rpc command on LndNode::new.