### PR TITLE
Removes triggers from consume_events

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -288,7 +288,6 @@ impl Simulation {
                 node.clone(),
                 receiver,
                 executed_actions.clone(),
-                shutdown.clone(),
             ));
 
             // Add the producer channel to our map so that various activity descriptions can use it. We may have multiple
@@ -319,7 +318,6 @@ async fn consume_events(
     node: Arc<Mutex<dyn LightningNode + Send>>,
     mut receiver: Receiver<NodeAction>,
     sender: Sender<ActionOutcome>,
-    shutdown: triggered::Trigger,
 ) {
     let node_id = node.lock().await.get_info().pubkey;
     log::debug!("Started consumer for {}", node_id);
@@ -369,9 +367,6 @@ async fn consume_events(
             }
         };
     }
-
-    // On exit call our shutdown trigger to inform other threads that we have exited, and they need to shut down.
-    shutdown.trigger();
 }
 
 // produce events generates events for the activity description provided. It accepts a shutdown listener so it can


### PR DESCRIPTION
We really don't need a trigger in consume_events. If a consumer is dropped, the channel is dropped, and the consumer will be signaled through the channel and break the execution already