### PR TITLE
feat: clean shutdown simulation on sigterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+dependencies = [
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +779,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1217,7 @@ dependencies = [
  "anyhow",
  "bitcoin 0.30.1",
  "clap",
+ "ctrlc",
  "log",
  "serde",
  "serde_json",
@@ -1278,6 +1301,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "std-ext"

--- a/sim-cli/Cargo.toml
+++ b/sim-cli/Cargo.toml
@@ -15,3 +15,4 @@ simple_logger = "2.1.0"
 sim-lib = { path = "../sim-lib" }
 tokio = { version = "1.26.0", features = ["full"] }
 bitcoin = { version = "0.30.1" }
+ctrlc = "3.4.0"

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -44,7 +44,14 @@ async fn main() -> anyhow::Result<()> {
         clients.insert(node.id, Arc::new(Mutex::new(lnd)));
     }
 
-    let sim = Simulation::new(clients, activity);
+    let sim = Arc::new(Simulation::new(clients, activity));
+    let sim2 = sim.clone();
+
+    ctrlc::set_handler(move || {
+        log::info!("Shutting down simulation...");
+        sim2.shutdown();
+    })?;
+
     sim.run().await?;
 
     Ok(())


### PR DESCRIPTION
capture sigterm from `sim-cli` and issue simulation shutdown. this allows us to complete tasks like report writing, before simulation exit

fixes #58 