### PR TITLE
fix: show failure reason in csv report

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use csv::WriterBuilder;
-use lightning::events::PaymentFailureReason;
 use lightning::ln::PaymentHash;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -16,6 +15,7 @@ use tokio::time;
 use triggered::{Listener, Trigger};
 
 pub mod lnd;
+mod serializers;
 
 const KEYSEND_OPTIONAL: u32 = 55;
 
@@ -116,10 +116,22 @@ enum NodeAction {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentResult {
-    pub settled: bool,
     pub htlc_count: usize,
-    #[serde(skip)]
-    pub failure_reason: Option<PaymentFailureReason>,
+    pub payment_outcome: PaymentOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PaymentOutcome {
+    Success,
+    RecipientRejected,
+    UserAbandoned,
+    RetriesExhausted,
+    PaymentExpired,
+    RouteNotFound,
+    UnexpectedError,
+    IncorrectPaymentDetails,
+    InsufficientBalance,
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -128,34 +140,13 @@ struct DispatchedPayment {
     source: PublicKey,
     destination: PublicKey,
     #[serde(
-        serialize_with = "serialize_payment_hash",
-        deserialize_with = "deserialize_payment_hash"
+        serialize_with = "serializers::serialize_payment_hash",
+        deserialize_with = "serializers::deserialize_payment_hash"
     )]
     hash: PaymentHash,
     amount_msat: u64,
     #[serde(with = "serde_millis")]
     dispatch_time: SystemTime,
-}
-
-fn serialize_payment_hash<S>(hash: &PaymentHash, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&hex::encode(hash.0))
-}
-
-fn deserialize_payment_hash<'de, D>(deserializer: D) -> Result<PaymentHash, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let bytes = hex::decode(s).map_err(serde::de::Error::custom)?;
-    let slice: [u8; 32] = bytes
-        .as_slice()
-        .try_into()
-        .map_err(serde::de::Error::custom)?;
-
-    Ok(PaymentHash(slice))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -547,9 +538,9 @@ impl PaymentResultLogger {
     }
 
     fn report_result(&mut self, details: &DispatchedPayment, result: &PaymentResult) {
-        match result.failure_reason {
-            Some(_) => self.failed_payment += 1,
-            None => self.success_payment += 1,
+        match result.payment_outcome {
+            PaymentOutcome::Success => self.success_payment += 1,
+            _ => self.failed_payment += 1,
         }
 
         self.total_sent += details.amount_msat;

--- a/sim-lib/src/serializers.rs
+++ b/sim-lib/src/serializers.rs
@@ -1,0 +1,23 @@
+use lightning::ln::PaymentHash;
+use serde::Deserialize;
+
+pub fn serialize_payment_hash<S>(hash: &PaymentHash, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&hex::encode(hash.0))
+}
+
+pub fn deserialize_payment_hash<'de, D>(deserializer: D) -> Result<PaymentHash, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let bytes = hex::decode(s).map_err(serde::de::Error::custom)?;
+    let slice: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(serde::de::Error::custom)?;
+
+    Ok(PaymentHash(slice))
+}


### PR DESCRIPTION
uses serializable `FailureReason` that we can then show in the generated report
```
source,destination,hash,amount_msat,dispatch_time,settled,htlc_count,failure_reason
02dd7ca90bac8579b7c5aa8b6eece032327b12f14314c59323d9ff9a5b65e1a63c,0378f52c4a103734795040a7d563df24a59c091a1d25d7acb3041a99bde8afbd13,43ebabbb538d9619042a066ad647d6ff80beeb6f5010113d4e87ff75f505f186,10000,1692366457128,true,0,RouteNotFound
02dd7ca90bac8579b7c5aa8b6eece032327b12f14314c59323d9ff9a5b65e1a63c,0378f52c4a103734795040a7d563df24a59c091a1d25d7acb3041a99bde8afbd13,bce62bc0b782904190d9a9dded1aabbb4c652f361531d28b184921b3dac23122,10000,1692366459132,true,0,RouteNotFound
```


fixes #63 