### PR TITLE
Normalizes node features so they use LDK NodeFeatures

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -101,7 +101,7 @@ pub enum LightningError {
 pub struct NodeInfo {
     pub pubkey: PublicKey,
     pub alias: String,
-    pub features: Vec<u32>,
+    pub features: NodeFeatures,
 }
 
 /// LightningNode represents the functionality that is required to execute events on a lightning node.


### PR DESCRIPTION
Currently we were using a pretty hacky way of parsing LND features that only parsed the keysend feature (given is the only we care about atm).

This PR properly loads the feature vector returned by LND's GetNodeInfo and parses it so a complete NodeFeatures object can be constructed.

Also sets NodeInfo::features to NodeFeatures for consistency