### PR TITLE
sim-lib: cleans unnecessary dead-code tags

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -151,7 +151,6 @@ pub enum PaymentOutcome {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[allow(dead_code)]
 struct DispatchedPayment {
     source: PublicKey,
     destination: PublicKey,

--- a/sim-lib/src/lnd.rs
+++ b/sim-lib/src/lnd.rs
@@ -18,7 +18,6 @@ use triggered::Listener;
 const KEYSEND_KEY: u64 = 5482373484;
 const SEND_PAYMENT_TIMEOUT_SECS: i32 = 300;
 
-#[allow(dead_code)]
 pub struct LndNode {
     client: Client,
     info: NodeInfo,


### PR DESCRIPTION
There were two dead-code tags that may have been missed from the last cleanup