### PR TITLE
multi: remove redundant resolver

### DIFF
--- a/sim-cli/Cargo.toml
+++ b/sim-cli/Cargo.toml
@@ -2,7 +2,6 @@
 name = "sim-cli"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -2,7 +2,6 @@
 name = "sim-lib"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Resolver is only required at a workspace level to clear the warning we were getting. 