### PR TITLE
readme: lock cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cd sim-ln
 
 Install the CLI: 
 ```
-cargo install --path sim-cli/
+cargo install --locked --path sim-cli/
 ```
 
 Run Simulation with Config: 


### PR DESCRIPTION
Without `--locked`, `cargo install` is free to upgrade dependencies to any minor versions. 

This can cause problems: see [issue](https://github.com/bitcoin-dev-project/sim-ln/issues/87), [original report](https://github.com/bitcoin-dev-project/sim-ln/pull/88#pullrequestreview-1625226199) and [summary](https://github.com/bitcoin-dev-project/sim-ln/pull/88#issuecomment-1719880940) for details. 