### PR TITLE
lnd: set no fee limit on payments

### DIFF
--- a/sim-lib/src/lnd.rs
+++ b/sim-lib/src/lnd.rs
@@ -104,6 +104,7 @@ impl LightningNode for LndNode {
                 dest_custom_records,
                 payment_hash,
                 timeout_seconds: SEND_PAYMENT_TIMEOUT_SECS,
+                fee_limit_msat: i64::max_value(),
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
When we don't set a fee limit for payments, LND will set the limit to the amount of the payment. This can make smaller payments fail in scenarios where the default base fee is more than the payment amount.

We update our sending code to have no fee limit, because we're more concerned with payment activity than fees. If we'd like to think about fees, we'll surface this on an activity and pass it through.