### PR TITLE
Allows using aliases within the config file

### DIFF
--- a/sim-lib/src/cln.rs
+++ b/sim-lib/src/cln.rs
@@ -9,15 +9,26 @@ use cln_grpc::pb::{
 use lightning::ln::features::NodeFeatures;
 use lightning::ln::PaymentHash;
 
+use serde::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, Error};
 use tokio::time::{self, Duration};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 use triggered::Listener;
 
-use crate::{
-    ClnConnection, LightningError, LightningNode, NodeInfo, PaymentOutcome, PaymentResult,
-};
+use crate::{serializers, LightningError, LightningNode, NodeInfo, PaymentOutcome, PaymentResult};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClnConnection {
+    pub id: PublicKey,
+    pub address: String,
+    #[serde(deserialize_with = "serializers::deserialize_path")]
+    pub ca_cert: String,
+    #[serde(deserialize_with = "serializers::deserialize_path")]
+    pub client_cert: String,
+    #[serde(deserialize_with = "serializers::deserialize_path")]
+    pub client_key: String,
+}
 
 pub struct ClnNode {
     pub client: NodeClient<Channel>,

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -33,31 +33,9 @@ pub const ACTIVITY_MULTIPLIER: f64 = 2.0;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum NodeConnection {
     #[serde(alias = "lnd", alias = "Lnd")]
-    LND(LndConnection),
+    LND(lnd::LndConnection),
     #[serde(alias = "cln", alias = "Cln")]
-    CLN(ClnConnection),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct LndConnection {
-    pub id: PublicKey,
-    pub address: String,
-    #[serde(deserialize_with = "serializers::deserialize_path")]
-    pub macaroon: String,
-    #[serde(deserialize_with = "serializers::deserialize_path")]
-    pub cert: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ClnConnection {
-    pub id: PublicKey,
-    pub address: String,
-    #[serde(deserialize_with = "serializers::deserialize_path")]
-    pub ca_cert: String,
-    #[serde(deserialize_with = "serializers::deserialize_path")]
-    pub client_cert: String,
-    #[serde(deserialize_with = "serializers::deserialize_path")]
-    pub client_key: String,
+    CLN(cln::ClnConnection),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -38,6 +38,32 @@ pub enum NodeConnection {
     CLN(cln::ClnConnection),
 }
 
+#[derive(Serialize, Debug, Clone)]
+pub enum NodeId {
+    PublicKey(PublicKey),
+    Alias(String),
+}
+
+impl NodeId {
+    pub fn validate(&self, node_id: &PublicKey, alias: &mut String) -> Result<(), LightningError> {
+        match self {
+            crate::NodeId::PublicKey(pk) => {
+                if pk != node_id {
+                    return Err(LightningError::ValidationError(format!(
+                    "the provided node id does not match the one returned by the backend ({} != {}).", pk, node_id)));
+                }
+            }
+            crate::NodeId::Alias(a) => {
+                if alias != a {
+                    log::warn!("The provided alias does not match the one returned by the backend ({} != {}).", a, alias)
+                }
+                *alias = a.to_string();
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub nodes: Vec<NodeConnection>,

--- a/sim-lib/src/serializers.rs
+++ b/sim-lib/src/serializers.rs
@@ -2,7 +2,6 @@ use expanduser::expanduser;
 use serde::Deserialize;
 
 pub mod serde_option_payment_hash {
-
     use lightning::ln::PaymentHash;
 
     pub fn serialize<S>(hash: &Option<PaymentHash>, serializer: S) -> Result<S::Ok, S::Error>
@@ -12,6 +11,36 @@ pub mod serde_option_payment_hash {
         match hash {
             Some(hash) => serializer.serialize_str(&hex::encode(hash.0)),
             None => serializer.serialize_str("Unknown"),
+        }
+    }
+}
+
+pub mod serde_node_id {
+    use super::*;
+    use std::str::FromStr;
+
+    use crate::NodeId;
+    use bitcoin::secp256k1::PublicKey;
+
+    pub fn serialize<S>(id: &NodeId, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&match id {
+            NodeId::PublicKey(p) => p.to_string(),
+            NodeId::Alias(s) => s.to_string(),
+        })
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<NodeId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if let Ok(pk) = PublicKey::from_str(&s) {
+            Ok(NodeId::PublicKey(pk))
+        } else {
+            Ok(NodeId::Alias(s))
         }
     }
 }


### PR DESCRIPTION
The goal of this PR is to allow aliases to be used throughout the config file to identify nodes, so the file is more human-readable. This involves:

- [x] Allow aliases to be defined as node identifiers
- [x] Allow aliases to be used as `source` of activities
- [x] Allow aliases to be used as `destination` of activities **as long as we control those nodes***
- [x] Include both aliases and short versions of public keys when logging activities 

\* We cannot use aliases as `destination` for nodes we don't control, given we have no way of mapping the aliases to the nodes' public keys. Notice aliases here do not have to match node aliases, they are just user-defined identifiers, and even if they did, node aliases don't have to be unique.

