### PR TITLE
Renames config file to sim file

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -7,16 +7,16 @@ use tokio::sync::Mutex;
 use clap::Parser;
 use log::LevelFilter;
 use sim_lib::{
-    cln::ClnNode, lnd::LndNode, ActivityDefinition, Config, LightningError, LightningNode,
-    NodeConnection, NodeId, Simulation,
+    cln::ClnNode, lnd::LndNode, ActivityDefinition, LightningError, LightningNode, NodeConnection,
+    NodeId, SimParams, Simulation,
 };
 use simple_logger::SimpleLogger;
 
 #[derive(Parser)]
 #[command(version)]
 struct Cli {
-    #[clap(long, short)]
-    config: PathBuf,
+    #[clap(index = 1)]
+    sim_file: PathBuf,
     #[clap(long, short)]
     total_time: Option<u32>,
     /// Number of activity results to batch together before printing to csv file
@@ -37,8 +37,8 @@ async fn main() -> anyhow::Result<()> {
         .init()
         .unwrap();
 
-    let config_str = std::fs::read_to_string(cli.config)?;
-    let Config { nodes, activity } = serde_json::from_str(&config_str)?;
+    let SimParams { nodes, activity } =
+        serde_json::from_str(&std::fs::read_to_string(cli.sim_file)?)?;
 
     let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode + Send>>> = HashMap::new();
     let mut pk_node_map = HashMap::new();

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for NodeId {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Config {
+pub struct SimParams {
     pub nodes: Vec<NodeConnection>,
     #[serde(default)]
     pub activity: Vec<ActivityParser>,


### PR DESCRIPTION
Currently we are using the term config file for the file that contains the simulation details. This is kind of fine for now, but it will get messy down the line when we want to start storing default values for the CLI parameters in a config file. Furthermore, we are requiring the config file to be passed, but `--config` is required.

This both renames config to sim, and makes the parameter positional instead of named.