### PR TITLE
sim-all: Adds description to both existing creates

### DIFF
--- a/sim-cli/Cargo.toml
+++ b/sim-cli/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sim-cli"
 version = "0.1.0"
 edition = "2021"
+description = """
+Instantly simulate real-world Lightning network activity
+"""
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -13,7 +13,7 @@ use sim_lib::{
 use simple_logger::SimpleLogger;
 
 #[derive(Parser)]
-#[command(version)]
+#[command(version, about)]
 struct Cli {
     #[clap(index = 1)]
     sim_file: PathBuf,

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sim-lib"
 version = "0.1.0"
 edition = "2021"
+description = """
+Backend logic of the SimLN project. Contains all the functionality to build your own simulator
+"""
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Mainly so we can have something nice when running `--help`