### PR TITLE
docker: fix setup-volume sed command

### DIFF
--- a/docker/setup-volume.sh
+++ b/docker/setup-volume.sh
@@ -41,8 +41,8 @@ for (( i=0; i<$NODE_COUNT; i++ )); do
     cp $NODE_MACAROON_PATH_ON_HOST $STAGING_DIR/lnd/$NODE_ID/admin.macaroon
 
     # Adjust the paths in the staging sim.json so we don't use the host path
-    sed -i '' 's|'$(dirname $NODE_TLS_PATH_ON_HOST)'/tls.cert|/data/lnd/'$NODE_ID'/tls.cert|' $STAGING_DIR/sim.json
-    sed -i '' 's|'$(dirname $NODE_MACAROON_PATH_ON_HOST)'/admin.macaroon|/data/lnd/'$NODE_ID'/admin.macaroon|' $STAGING_DIR/sim.json
+    sed -i 's|'$(dirname $NODE_TLS_PATH_ON_HOST)'/tls.cert|/data/lnd/'$NODE_ID'/tls.cert|' $STAGING_DIR/sim.json
+    sed -i 's|'$(dirname $NODE_MACAROON_PATH_ON_HOST)'/admin.macaroon|/data/lnd/'$NODE_ID'/admin.macaroon|' $STAGING_DIR/sim.json
 done
 
 # Create Docker volume and copy the data


### PR DESCRIPTION
I am running macOS but with GNU sed installed (instead of the default openBSD sed)

```
--> sed --version
sed (GNU sed) 4.9
```

SO it seems that this version at least does not need the empty string parameter. It ends up interpreting the string replacement script as a file path:

```
--> make mount-volume SIMFILE_PATH=/Users/matthewzipkin/.warnet/warnet/warnet/simln/sim.json
chmod +x ./docker/setup-volume.sh && ./docker/setup-volume.sh "/Users/matthewzipkin/.warnet/warnet/warnet/simln/sim.json"
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/tls.cert\/data/lnd/warnet_ln_000000/tls.cert\: No such file or directory
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/admin.macaroon\/data/lnd/warnet_ln_000000/admin.macaroon\: No such file or directory
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/tls.cert\/data/lnd/warnet_ln_000001/tls.cert\: No such file or directory
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/admin.macaroon\/data/lnd/warnet_ln_000001/admin.macaroon\: No such file or directory
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/tls.cert\/data/lnd/warnet_ln_000002/tls.cert\: No such file or directory
sed: can't read s\/Users/matthewzipkin/.warnet/warnet/warnet/simln/admin.macaroon\/data/lnd/warnet_ln_000002/admin.macaroon\: No such file or directory
```