### PR TITLE
sim-all: Adds tests coverage to `random_activity`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8ec6d2b73d45307e926f5af46809768581044384637af6b3f3fe7c3c88f512"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7d33be719c6f4d09e64e27c1ef4e73485dc4cc1f4d22201f89860a7fe22e22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1146,16 @@ checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1661,6 +1704,7 @@ dependencies = [
  "lightning",
  "log",
  "mpsc",
+ "ntest",
  "rand",
  "rand_distr",
  "serde",
@@ -1922,6 +1966,23 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.2",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2375,3 +2436,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+dependencies = [
+ "memchr",
+]

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -39,10 +39,10 @@ struct Cli {
     #[clap(long, short, verbatim_doc_comment, default_value = "info")]
     log_level: LevelFilter,
     /// Expected payment amount for the random activity generator
-    #[clap(long, short, default_value_t = EXPECTED_PAYMENT_AMOUNT)]
+    #[clap(long, short, default_value_t = EXPECTED_PAYMENT_AMOUNT, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..u64::MAX))]
     expected_pmt_amt: u64,
     /// Multiplier of the overall network capacity used by the random activity generator
-    #[clap(long, short, default_value_t = ACTIVITY_MULTIPLIER)]
+    #[clap(long, short, default_value_t = ACTIVITY_MULTIPLIER, value_parser = clap::builder::RangedU64ValueParser::<u32>::new().range(1..u64::MAX))]
     capacity_multiplier: f64,
     /// Do not create an output file containing the simulations results
     #[clap(long, default_value_t = false)]

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -29,3 +29,6 @@ hex = "0.4.3"
 csv = "1.2.2"
 serde_millis = "0.1.1"
 rand_distr = "0.4.3"
+
+[dev-dependencies]
+ntest = "0.9.0"

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -23,6 +23,8 @@ pub mod cln;
 pub mod lnd;
 mod random_activity;
 mod serializers;
+#[cfg(test)]
+mod test_utils;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]

--- a/sim-lib/src/test_utils.rs
+++ b/sim-lib/src/test_utils.rs
@@ -1,0 +1,28 @@
+use rand::distributions::Uniform;
+use rand::Rng;
+
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+/// Utility function to create a vector of pseudo random bytes.
+///
+/// Mainly used for testing purposes.
+pub fn get_random_bytes(size: usize) -> Vec<u8> {
+    rand::thread_rng()
+        .sample_iter(Uniform::new(u8::MIN, u8::MAX))
+        .take(size)
+        .collect()
+}
+
+/// Utility function to create a random integer in a given range
+pub fn get_random_int(s: u64, e: u64) -> u64 {
+    rand::thread_rng().gen_range(s..e)
+}
+
+/// Gets a key pair generated in a pseudorandom way.
+pub fn get_random_keypair() -> (SecretKey, PublicKey) {
+    loop {
+        if let Ok(sk) = SecretKey::from_slice(&get_random_bytes(32)) {
+            return (sk, PublicKey::from_secret_key(&Secp256k1::new(), &sk));
+        }
+    }
+}


### PR DESCRIPTION
This is a first stab at adding tests to the simulator.

Adds tests to the random activity generator and includes some sanity checks to `sim-cli` so we can fail early if we need to.