### PR TITLE
sim-cli: Improves CLI docs so help has a more friendly report

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -12,22 +12,37 @@ use sim_lib::{
 };
 use simple_logger::SimpleLogger;
 
+/// The default expected payment amount for the simulation, around ~$10 at the time of writing.
+pub const EXPECTED_PAYMENT_AMOUNT: u64 = 3_800_000;
+
+/// The number of times over each node in the network sends its total deployed capacity in a calendar month.
+pub const ACTIVITY_MULTIPLIER: f64 = 2.0;
+
+/// Default batch size to flush result data to disk
+const DEFAULT_PRINT_BATCH_SIZE: u32 = 500;
+
 #[derive(Parser)]
 #[command(version, about)]
 struct Cli {
+    /// Path to the simulation file to be used by the simulator
     #[clap(index = 1)]
     sim_file: PathBuf,
+    /// Total time the simulator will be running
     #[clap(long, short)]
     total_time: Option<u32>,
-    /// Number of activity results to batch together before printing to csv file
-    #[clap(long, short)]
-    print_batch_size: Option<u32>,
-    #[clap(long, short, default_value = "info")]
+    /// Number of activity results to batch together before printing to csv file [min: 1]
+    #[clap(long, short, default_value_t = DEFAULT_PRINT_BATCH_SIZE, value_parser = clap::builder::RangedU64ValueParser::<u32>::new().range(1..u32::MAX as u64))]
+    print_batch_size: u32,
+    /// Level of verbosity of the messages displayed by the simulator.
+    /// Possible values: [off, error, warn, info, debug, trace]
+    #[clap(long, short, verbatim_doc_comment, default_value = "info")]
     log_level: LevelFilter,
-    #[clap(long, short)]
-    expected_pmt_amt: Option<u64>,
-    #[clap(long, short)]
-    capacity_multiplier: Option<f64>,
+    /// Expected payment amount for the random activity generator
+    #[clap(long, short, default_value_t = EXPECTED_PAYMENT_AMOUNT)]
+    expected_pmt_amt: u64,
+    /// Multiplier of the overall network capacity used by the random activity generator
+    #[clap(long, short, default_value_t = ACTIVITY_MULTIPLIER)]
+    capacity_multiplier: f64,
 }
 
 #[tokio::main]

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -24,12 +24,6 @@ pub mod lnd;
 mod random_activity;
 mod serializers;
 
-/// The default expected payment amount for the simulation, around ~$10 at the time of writing.
-pub const EXPECTED_PAYMENT_AMOUNT: u64 = 3_800_000;
-
-/// The number of times over each node in the network sends its total deployed capacity in a calendar month.
-pub const ACTIVITY_MULTIPLIER: f64 = 2.0;
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum NodeConnection {
     #[serde(alias = "lnd", alias = "Lnd")]
@@ -336,16 +330,14 @@ pub struct Simulation {
     activity_multiplier: f64,
 }
 
-const DEFAULT_PRINT_BATCH_SIZE: u32 = 500;
-
 impl Simulation {
     pub fn new(
         nodes: HashMap<PublicKey, Arc<Mutex<dyn LightningNode + Send>>>,
         activity: Vec<ActivityDefinition>,
         total_time: Option<u32>,
-        print_batch_size: Option<u32>,
-        expected_payment_amount: Option<u64>,
-        activity_multiplier: Option<f64>,
+        print_batch_size: u32,
+        expected_payment_msat: u64,
+        activity_multiplier: f64,
     ) -> Self {
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         Self {
@@ -354,9 +346,9 @@ impl Simulation {
             shutdown_trigger,
             shutdown_listener,
             total_time: total_time.map(|x| Duration::from_secs(x as u64)),
-            print_batch_size: print_batch_size.unwrap_or(DEFAULT_PRINT_BATCH_SIZE),
-            expected_payment_msat: expected_payment_amount.unwrap_or(EXPECTED_PAYMENT_AMOUNT),
-            activity_multiplier: activity_multiplier.unwrap_or(ACTIVITY_MULTIPLIER),
+            print_batch_size,
+            expected_payment_msat,
+            activity_multiplier,
         }
     }
 


### PR DESCRIPTION
`sim-cli help` is pretty unfriendly atm, add docs so the args/options are covered. 

This makes some optional params to the simulator mandatory and moves the defaulting behavior to the CLI so clap can take care of it. The main rationale for it is so we can easily report the defaults.

Also, restricts `print_batch_size` to be `> 0`, as discussed https://github.com/bitcoin-dev-project/sim-ln/pull/146#issuecomment-1771101726
