### PR TITLE
sim-lib: Get rid of nested json for node definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,33 @@ sim-cli sim.json
 The simulator requires access details for a set of `nodes` that you 
 have permission to execute commands on. Note that the current version 
 of the simulator uses keysend to execute payments, which must be 
-enabled in LND using `--accept-keysend`.
+enabled in LND using `--accept-keysend` (for CLN node it is enabled by default).
+
+The required access details will depend on the node implementation. For LND, the following
+information is required:
+
+```
+{
+  "id": <node_id>,
+  "address": https://<ip:port or domain:port>,
+  "macaroon": <path_to_selected_macaroon>,
+  "cert": <path_to_tls_cert>
+}
+```
+
+Whereas for CLN nodes, the following information is required:
+
+```
+{ 
+  "id": <node_id>,
+  "address": https://<ip:port or domain:port>,
+  "ca_cert": <path_to_ca_cert>,
+  "client_cert": <path_to_client_cert>,
+  "client_key": <path_to_client_key>
+}
+```
+
+**Note that node addresses must be declare with HTTPS transport, i.e. <https://ip-or-domain:port>**
 
 Payment activity can be simulated in two different ways:
 * Random activity: generate random activity on the `nodes` provided, 
@@ -85,8 +111,6 @@ not "drain" from the simulation.
   ]
 }
 ```
-
-**Note that node addresses must be declare with HTTPS transport, i.e. <https://ip-or-domain>**
 
 Nodes can be identified by an arbitrary string ("Alice", "CLN1", etc) or
 by their node public key. If a valid public key is provided it *must* 

--- a/README.md
+++ b/README.md
@@ -70,21 +70,17 @@ not "drain" from the simulation.
 {
   "nodes": [
     {
-      "LND": {
-        "id": "Alice",
-        "address": "https://127.0.0.1:10011",
-        "macaroon": "/path/admin.macaroon",
-        "cert": "/path/tls.cert"
-      }
+      "id": "Alice",
+      "address": "https://127.0.0.1:10011",
+      "macaroon": "/path/admin.macaroon",
+      "cert": "/path/tls.cert"
     },
-    {
-      "CLN": {
-        "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
-        "address": "https://localhost:10013",
-        "ca_cert": "/path/ca.pem",
-        "client_cert": "/path/client.pem",
-        "client_key": "/path/client-key.pem"
-      }
+    { 
+      "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
+      "address": "https://localhost:10013",
+      "ca_cert": "/path/ca.pem",
+      "client_cert": "/path/client.pem",
+      "client_key": "/path/client-key.pem"
     }
   ]
 }
@@ -126,21 +122,17 @@ The example simulation file below sets up the following simulation:
 {
   "nodes": [
     {
-      "LND": {
-        "id": "Alice",
-        "address": "https://localhost:10011",
-        "macaroon": "/path/admin.macaroon",
-        "cert": "/path/tls.cert"
-      }
+      "id": "Alice",
+      "address": "https://localhost:10011",
+      "macaroon": "/path/admin.macaroon",
+      "cert": "/path/tls.cert"
     },
     {
-      "CLN": {
-        "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
-        "address": "https://127.0.0.1:10013",
-        "ca_cert": "/path/ca.pem",
-        "client_cert": "/path/client.pem",
-        "client_key": "/path/client-key.pem"
-      }
+      "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
+      "address": "https://127.0.0.1:10013",
+      "ca_cert": "/path/ca.pem",
+      "client_cert": "/path/client.pem",
+      "client_key": "/path/client-key.pem"
     }
   ],
   "activity": [

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,12 +51,10 @@ For instance, in your configuration:
 
 ```json
 {
-  "LND": {
-    "id": "022579561f6f0ea86e330df2f9e7b2be3e0a53f8552f9d5293b80dfc1038f2f66d",
-    "address": "https://host.docker.internal:10002",
-    "macaroon": "/path/in/container/lnd/bob/data/chain/bitcoin/regtest/admin.macaroon",
-    "cert": "/path/in/container/lnd/bob/tls.cert"
-  }
+  "id": "022579561f6f0ea86e330df2f9e7b2be3e0a53f8552f9d5293b80dfc1038f2f66d",
+  "address": "https://host.docker.internal:10002",
+  "macaroon": "/path/in/container/lnd/bob/data/chain/bitcoin/regtest/admin.macaroon",
+  "cert": "/path/in/container/lnd/bob/tls.cert"
 }
 ```
 

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use anyhow::anyhow;
 use clap::Parser;
 use log::LevelFilter;
 use sim_lib::{
@@ -60,7 +61,8 @@ async fn main() -> anyhow::Result<()> {
         .unwrap();
 
     let SimParams { nodes, activity } =
-        serde_json::from_str(&std::fs::read_to_string(cli.sim_file)?)?;
+        serde_json::from_str(&std::fs::read_to_string(cli.sim_file)?)
+            .map_err(|e| anyhow!("Could not deserialize node connection data or activity description from simulation file (line {}, col {}).", e.line(), e.column()))?;
 
     let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode + Send>>> = HashMap::new();
     let mut pk_node_map = HashMap::new();

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -25,10 +25,9 @@ mod random_activity;
 mod serializers;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
 pub enum NodeConnection {
-    #[serde(alias = "lnd", alias = "Lnd")]
     LND(lnd::LndConnection),
-    #[serde(alias = "cln", alias = "Cln")]
     CLN(cln::ClnConnection),
 }
 


### PR DESCRIPTION
I must have been way more sleep-deprived than I thought when originally designing this, but we don't really need the nested json with node type tags to parse node information (as long as the node info has, **at least** one different field name).

Mainly, this goes from:

```json
"nodes": [
    {
        "LND": {
            "id": "...",
            "address": "...",
            "macaroon": "...",
            "cert": "..."
        }
    },
    {
        "CLN": {
            "id": "...",
            "address": "...",
            "ca_cert": "...",
            "client_cert": "...",
            "client_key": "..."
        }
    }
]
```

To:

```json
"nodes": [
    {
        "id": "...",
        "address": "...",
        "macaroon": "...",
        "cert": "..."
    },
    {
        "id": "...",
        "address": "...",
        "ca_cert": "...",
        "client_cert": "...",
        "client_key": "..."
    }
]
```