### PR TITLE
sim-cli: remove broken parser for activity multiplier

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -42,7 +42,7 @@ struct Cli {
     #[clap(long, short, default_value_t = EXPECTED_PAYMENT_AMOUNT, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..u64::MAX))]
     expected_pmt_amt: u64,
     /// Multiplier of the overall network capacity used by the random activity generator
-    #[clap(long, short, default_value_t = ACTIVITY_MULTIPLIER, value_parser = clap::builder::RangedU64ValueParser::<u32>::new().range(1..u64::MAX))]
+    #[clap(long, short, default_value_t = ACTIVITY_MULTIPLIER)]
     capacity_multiplier: f64,
     /// Do not create an output file containing the simulations results
     #[clap(long, default_value_t = false)]


### PR DESCRIPTION
u64 parser does not work for a f64 value. 

Broken on main:
```
sim-cli sim.json
thread 'main' panicked at 'Mismatch between definition and access of `capacity_multiplier`. Could not downcast to TypeId { t: 8711759054683223602271599665973969982 }, need to downcast to TypeId { t: 25882202575019293479932656973818029271 }
', /Users/carla/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.6/src/parser/error.rs:32:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

```
sim-cli sim.json --capacity-multiplier 0.5
error: invalid value '0.5' for '--capacity-multiplier <CAPACITY_MULTIPLIER>': invalid digit found in string
```


