### PR TITLE
refactor: Unify Dispatch of Random and Defined Activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /target
 node_modules
-config.json
-sim.json
-package-lock.json
+*.json
 activity-generator/releases/*
 .DS_Store
 /results

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
         serde_json::from_str(&std::fs::read_to_string(sim_path)?)
             .map_err(|e| anyhow!("Could not deserialize node connection data or activity description from simulation file (line {}, col {}).", e.line(), e.column()))?;
 
-    let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode + Send>>> = HashMap::new();
+    let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> = HashMap::new();
     let mut pk_node_map = HashMap::new();
     let mut alias_node_map = HashMap::new();
 
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
         // TODO: Feels like there should be a better way of doing this without having to Arc<Mutex<T>>> it at this time.
         // Box sort of works, but we won't know the size of the dyn LightningNode at compile time so the compiler will
         // scream at us when trying to create the Arc<Mutex>> later on while adding the node to the clients map
-        let node: Arc<Mutex<dyn LightningNode + Send>> = match connection {
+        let node: Arc<Mutex<dyn LightningNode>> = match connection {
             NodeConnection::LND(c) => Arc::new(Mutex::new(LndNode::new(c).await?)),
             NodeConnection::CLN(c) => Arc::new(Mutex::new(ClnNode::new(c).await?)),
         };

--- a/sim-lib/src/defined_activity.rs
+++ b/sim-lib/src/defined_activity.rs
@@ -1,0 +1,85 @@
+use crate::{DestinationGenerator, NodeInfo, PaymentGenerationError, PaymentGenerator};
+use std::fmt;
+use tokio::time::Duration;
+
+#[derive(Clone)]
+pub struct DefinedPaymentActivity {
+    destination: NodeInfo,
+    wait: Duration,
+    amount: u64,
+}
+
+impl DefinedPaymentActivity {
+    pub fn new(destination: NodeInfo, wait: Duration, amount: u64) -> Self {
+        DefinedPaymentActivity {
+            destination,
+            wait,
+            amount,
+        }
+    }
+}
+
+impl fmt::Display for DefinedPaymentActivity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "static payment of {} to {} every {:?}",
+            self.amount, self.destination, self.wait
+        )
+    }
+}
+
+impl DestinationGenerator for DefinedPaymentActivity {
+    fn choose_destination(&self, _: bitcoin::secp256k1::PublicKey) -> (NodeInfo, Option<u64>) {
+        (self.destination.clone(), None)
+    }
+}
+
+impl PaymentGenerator for DefinedPaymentActivity {
+    fn next_payment_wait(&self) -> Duration {
+        self.wait
+    }
+
+    fn payment_amount(
+        &self,
+        destination_capacity: Option<u64>,
+    ) -> Result<u64, crate::PaymentGenerationError> {
+        if destination_capacity.is_some() {
+            Err(PaymentGenerationError(
+                "destination amount must not be set for defined activity generator".to_string(),
+            ))
+        } else {
+            Ok(self.amount)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DefinedPaymentActivity;
+    use crate::test_utils::{create_nodes, get_random_keypair};
+    use crate::{DestinationGenerator, PaymentGenerationError, PaymentGenerator};
+    use std::time::Duration;
+
+    #[test]
+    fn test_defined_activity_generator() {
+        let node = create_nodes(1, 100000);
+        let node = &node.first().unwrap().0;
+
+        let source = get_random_keypair();
+        let payment_amt = 50;
+
+        let generator =
+            DefinedPaymentActivity::new(node.clone(), Duration::from_secs(60), payment_amt);
+
+        let (dest, dest_capacity) = generator.choose_destination(source.1);
+        assert_eq!(node.pubkey, dest.pubkey);
+        assert!(dest_capacity.is_none());
+
+        assert_eq!(payment_amt, generator.payment_amount(None).unwrap());
+        assert!(matches!(
+            generator.payment_amount(Some(10)),
+            Err(PaymentGenerationError(..))
+        ));
+    }
+}

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinSet;
 use tokio::{select, time, time::Duration};
 use triggered::{Listener, Trigger};
 
-use self::random_activity::{NetworkGraphView, PaymentActivityGenerator};
+use self::random_activity::{NetworkGraphView, RandomPaymentActivity};
 
 pub mod cln;
 pub mod lnd;
@@ -582,10 +582,9 @@ impl Simulation {
         for (pk, node) in self.nodes.iter() {
             let chan_capacity = node.lock().await.list_channels().await?.iter().sum::<u64>();
 
-            if let Err(e) = PaymentActivityGenerator::validate_capacity(
-                chan_capacity,
-                self.expected_payment_msat,
-            ) {
+            if let Err(e) =
+                RandomPaymentActivity::validate_capacity(chan_capacity, self.expected_payment_msat)
+            {
                 log::warn!("Node: {} not eligible for activity generation: {e}.", *pk);
                 continue;
             }
@@ -684,7 +683,7 @@ impl Simulation {
                 }
             };
 
-            let node_generator = PaymentActivityGenerator::new(
+            let node_generator = RandomPaymentActivity::new(
                 source_capacity,
                 self.expected_payment_msat,
                 self.activity_multiplier,

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -202,9 +202,9 @@ pub trait LightningNode {
 }
 
 pub trait DestinationGenerator {
-    // sample_node_by_capacity randomly picks a node within the network weighted by its capacity deployed to the
-    // network in channels. It returns the node's public key and its capacity in millisatoshis.
-    fn sample_node_by_capacity(&self, source: PublicKey) -> (NodeInfo, u64);
+    // choose_destination picks a destination node within the network, returning the node's information and its
+    // capacity.
+    fn choose_destination(&self, source: PublicKey) -> (NodeInfo, u64);
 }
 
 #[derive(Debug, Error)]
@@ -849,7 +849,7 @@ async fn produce_random_events<N: DestinationGenerator, A: PaymentGenerator + Di
             // Wait until our time to next payment has elapsed then execute a random amount payment to a random
             // destination.
             _ = time::sleep(wait) => {
-                let (destination, capacity) = network_generator.lock().await.sample_node_by_capacity(source.pubkey);
+                let (destination, capacity) = network_generator.lock().await.choose_destination(source.pubkey);
 
                 // Only proceed with a payment if the amount is non-zero, otherwise skip this round. If we can't get
                 // a payment amount something has gone wrong (because we should have validated that we can always

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -22,6 +22,7 @@ use triggered::{Listener, Trigger};
 use self::random_activity::{NetworkGraphView, RandomPaymentActivity};
 
 pub mod cln;
+mod defined_activity;
 pub mod lnd;
 mod random_activity;
 mod serializers;

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -203,8 +203,8 @@ pub trait LightningNode {
 
 pub trait DestinationGenerator {
     // choose_destination picks a destination node within the network, returning the node's information and its
-    // capacity.
-    fn choose_destination(&self, source: PublicKey) -> (NodeInfo, u64);
+    // capacity (if available).
+    fn choose_destination(&self, source: PublicKey) -> (NodeInfo, Option<u64>);
 }
 
 #[derive(Debug, Error)]
@@ -214,8 +214,11 @@ pub trait PaymentGenerator {
     // Returns the number of seconds that a node should wait until firing its next payment.
     fn next_payment_wait(&self) -> time::Duration;
 
-    // Returns a payment amount based on the capacity of the sending and receiving node.
-    fn payment_amount(&self, destination_capacity: u64) -> Result<u64, PaymentGenerationError>;
+    // Returns a payment amount based, with a destination capacity optionally provided to inform the amount picked.
+    fn payment_amount(
+        &self,
+        destination_capacity: Option<u64>,
+    ) -> Result<u64, PaymentGenerationError>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -95,15 +95,15 @@ pub struct SimParams {
 /// [NodeId], which enables the use of public keys and aliases in the simulation description.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActivityParser {
-    // The source of the payment.
+    /// The source of the payment.
     #[serde(with = "serializers::serde_node_id")]
     pub source: NodeId,
-    // The destination of the payment.
+    /// The destination of the payment.
     #[serde(with = "serializers::serde_node_id")]
     pub destination: NodeId,
-    // The interval of the event, as in every how many seconds the payment is performed.
+    /// The interval of the event, as in every how many seconds the payment is performed.
     pub interval_secs: u16,
-    // The amount of m_sat to used in this payment.
+    /// The amount of m_sat to used in this payment.
     pub amount_msat: u64,
 }
 
@@ -111,13 +111,13 @@ pub struct ActivityParser {
 /// This is constructed during activity validation and passed along to the [Simulation].
 #[derive(Debug, Clone)]
 pub struct ActivityDefinition {
-    // The source of the payment.
+    /// The source of the payment.
     pub source: NodeInfo,
-    // The destination of the payment.
+    /// The destination of the payment.
     pub destination: NodeInfo,
-    // The interval of the event, as in every how many seconds the payment is performed.
+    /// The interval of the event, as in every how many seconds the payment is performed.
     pub interval_secs: u16,
-    // The amount of m_sat to used in this payment.
+    /// The amount of m_sat to used in this payment.
     pub amount_msat: u64,
 }
 
@@ -135,7 +135,6 @@ pub enum SimulationError {
     RandomActivityError(RandomActivityError),
 }
 
-// Phase 2: Event Queue
 #[derive(Debug, Error)]
 pub enum LightningError {
     #[error("Node connection error: {0}")]
@@ -204,8 +203,8 @@ pub trait LightningNode: Send {
 }
 
 pub trait DestinationGenerator: Send {
-    // choose_destination picks a destination node within the network, returning the node's information and its
-    // capacity (if available).
+    /// choose_destination picks a destination node within the network, returning the node's information and its
+    /// capacity (if available).
     fn choose_destination(&self, source: PublicKey) -> (NodeInfo, Option<u64>);
 }
 
@@ -214,10 +213,10 @@ pub trait DestinationGenerator: Send {
 pub struct PaymentGenerationError(String);
 
 pub trait PaymentGenerator: Display + Send {
-    // Returns the number of seconds that a node should wait until firing its next payment.
+    /// Returns the number of seconds that a node should wait until firing its next payment.
     fn next_payment_wait(&self) -> time::Duration;
 
-    // Returns a payment amount based, with a destination capacity optionally provided to inform the amount picked.
+    /// Returns a payment amount based, with a destination capacity optionally provided to inform the amount picked.
     fn payment_amount(
         &self,
         destination_capacity: Option<u64>,
@@ -324,14 +323,14 @@ enum SimulationOutput {
 
 #[derive(Clone)]
 pub struct Simulation {
-    // The lightning node that is being simulated.
+    /// The lightning node that is being simulated.
     nodes: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>,
-    // The activity that are to be executed on the node.
+    /// The activity that are to be executed on the node.
     activity: Vec<ActivityDefinition>,
-    // High level triggers used to manage simulation tasks and shutdown.
+    /// High level triggers used to manage simulation tasks and shutdown.
     shutdown_trigger: Trigger,
     shutdown_listener: Listener,
-    // Total simulation time. The simulation will run forever if undefined.
+    /// Total simulation time. The simulation will run forever if undefined.
     total_time: Option<time::Duration>,
     /// The expected payment size for the network.
     expected_payment_msat: u64,
@@ -425,7 +424,7 @@ impl Simulation {
         Ok(())
     }
 
-    // validates that the nodes are all on the same network and ensures that we're not running on mainnet.
+    /// validates that the nodes are all on the same network and ensures that we're not running on mainnet.
     async fn validate_node_network(&self) -> Result<(), LightningError> {
         if self.nodes.is_empty() {
             return Err(LightningError::ValidationError(
@@ -531,8 +530,8 @@ impl Simulation {
         self.shutdown_trigger.trigger()
     }
 
-    // run_data_collection starts the tasks required for the simulation to report of the results of the activity that
-    // it generates. The simulation should report outputs via the receiver that is passed in.
+    /// run_data_collection starts the tasks required for the simulation to report of the results of the activity that
+    /// it generates. The simulation should report outputs via the receiver that is passed in.
     fn run_data_collection(
         &self,
         output_receiver: Receiver<SimulationOutput>,
@@ -716,11 +715,11 @@ impl Simulation {
     }
 }
 
-// consume_events processes events that are crated for a lightning node that we can execute events on. Any output
-// that is generated from the event being executed is piped into a channel to handle the result of the event. If it
-// exits, it will use the trigger provided to trigger shutdown in other threads. If an error occurs elsewhere, we
-// expect the senders corresponding to our receiver to be dropped, which will cause the receiver to error out and
-// exit.
+/// events that are crated for a lightning node that we can execute events on. Any output that is generated from the
+/// event being executed is piped into a channel to handle the result of the event. If it exits, it will use the
+/// trigger provided to trigger shutdown in other threads. If an error occurs elsewhere, we expect the senders
+/// corresponding to our receiver to be dropped, which will cause the receiver to error out and
+/// exit.
 async fn consume_events(
     node: Arc<Mutex<dyn LightningNode>>,
     mut receiver: Receiver<SimulationEvent>,
@@ -787,8 +786,8 @@ async fn consume_events(
     }
 }
 
-// produce events generates events for the activity description provided. It accepts a shutdown listener so it can
-// exit if other threads signal that they have errored out.
+/// produce events generates events for the activity description provided. It accepts a shutdown listener so it can
+/// exit if other threads signal that they have errored out.
 async fn produce_events<N: DestinationGenerator + ?Sized, A: PaymentGenerator + ?Sized>(
     source: NodeInfo,
     network_generator: Arc<Mutex<N>>,

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -201,7 +201,7 @@ pub trait LightningNode {
     async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError>;
 }
 
-pub trait NetworkGenerator {
+pub trait DestinationGenerator {
     // sample_node_by_capacity randomly picks a node within the network weighted by its capacity deployed to the
     // network in channels. It returns the node's public key and its capacity in millisatoshis.
     fn sample_node_by_capacity(&self, source: PublicKey) -> (NodeInfo, u64);
@@ -826,7 +826,7 @@ async fn produce_events(
     shutdown.trigger();
 }
 
-async fn produce_random_events<N: NetworkGenerator, A: PaymentGenerator + Display>(
+async fn produce_random_events<N: DestinationGenerator, A: PaymentGenerator + Display>(
     source: NodeInfo,
     network_generator: Arc<Mutex<N>>,
     node_generator: A,

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -6,7 +6,7 @@ use bitcoin::secp256k1::PublicKey;
 use rand_distr::{Distribution, Exp, LogNormal, WeightedIndex};
 use std::time::Duration;
 
-use crate::{NetworkGenerator, NodeInfo, PaymentGenerationError, PaymentGenerator};
+use crate::{DestinationGenerator, NodeInfo, PaymentGenerationError, PaymentGenerator};
 
 const HOURS_PER_MONTH: u64 = 30 * 24;
 const SECONDS_PER_MONTH: u64 = HOURS_PER_MONTH * 60 * 60;
@@ -56,7 +56,7 @@ impl NetworkGraphView {
     }
 }
 
-impl NetworkGenerator for NetworkGraphView {
+impl DestinationGenerator for NetworkGraphView {
     /// Randomly samples the network for a node, weighted by capacity.  Using a single graph view means that it's
     /// possible for a source node to select itself. After sufficient retries, this is highly improbable (even  with
     /// very small graphs, or those with one node significantly more capitalized than others).

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -259,27 +259,10 @@ impl Display for RandomPaymentActivity {
 #[cfg(test)]
 mod tests {
     mod test_network_graph_view {
-        use lightning::ln::features::Features;
         use ntest::timeout;
 
         use super::super::*;
-        use crate::test_utils::get_random_keypair;
-        use crate::NodeInfo;
-
-        fn create_nodes(n: usize, node_capacity: u64) -> Vec<(NodeInfo, u64)> {
-            (1..=n)
-                .map(|_| {
-                    (
-                        NodeInfo {
-                            pubkey: get_random_keypair().1,
-                            alias: String::new(),
-                            features: Features::empty(),
-                        },
-                        node_capacity,
-                    )
-                })
-                .collect()
-        }
+        use crate::test_utils::create_nodes;
 
         #[test]
         fn test_new() {

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -29,9 +29,9 @@ pub struct NetworkGraphView {
 }
 
 impl NetworkGraphView {
-    // Creates a network view for the map of node public keys to capacity (in millisatoshis) provided. Returns an error
-    // if any node's capacity is zero (the node cannot receive), or there are not at least two nodes (one node can't
-    // send to itself).
+    /// Creates a network view for the map of node public keys to capacity (in millisatoshis) provided. Returns an error
+    /// if any node's capacity is zero (the node cannot receive), or there are not at least two nodes (one node can't
+    /// send to itself).
     pub fn new(nodes: Vec<(NodeInfo, u64)>) -> Result<Self, RandomActivityError> {
         if nodes.len() < 2 {
             return Err(RandomActivityError::ValueError(

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -60,7 +60,7 @@ impl DestinationGenerator for NetworkGraphView {
     /// Randomly samples the network for a node, weighted by capacity.  Using a single graph view means that it's
     /// possible for a source node to select itself. After sufficient retries, this is highly improbable (even  with
     /// very small graphs, or those with one node significantly more capitalized than others).
-    fn sample_node_by_capacity(&self, source: PublicKey) -> (NodeInfo, u64) {
+    fn choose_destination(&self, source: PublicKey) -> (NodeInfo, u64) {
         let mut rng = rand::thread_rng();
 
         // While it's very unlikely that we can't pick a destination that is not our source, it's possible that there's
@@ -333,7 +333,7 @@ mod tests {
             let view = NetworkGraphView::new(nodes).unwrap();
 
             for _ in 0..10 {
-                view.sample_node_by_capacity(big_node);
+                view.choose_destination(big_node);
             }
         }
     }

--- a/sim-lib/src/test_utils.rs
+++ b/sim-lib/src/test_utils.rs
@@ -1,7 +1,10 @@
+use lightning::ln::features::Features;
 use rand::distributions::Uniform;
 use rand::Rng;
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+use crate::NodeInfo;
 
 /// Utility function to create a vector of pseudo random bytes.
 ///
@@ -25,4 +28,20 @@ pub fn get_random_keypair() -> (SecretKey, PublicKey) {
             return (sk, PublicKey::from_secret_key(&Secp256k1::new(), &sk));
         }
     }
+}
+
+/// Creates n nodes with the capacity specified.
+pub fn create_nodes(n: usize, node_capacity: u64) -> Vec<(NodeInfo, u64)> {
+    (1..=n)
+        .map(|_| {
+            (
+                NodeInfo {
+                    pubkey: get_random_keypair().1,
+                    alias: String::new(),
+                    features: Features::empty(),
+                },
+                node_capacity,
+            )
+        })
+        .collect()
 }


### PR DESCRIPTION
This PR unifies dispatch of random and defined activities. I think that this is worthwhile doing: 
1. As a pathway to allowing users to specify *both* random and defined activity in future changes
2. To reduce code duplication (functionality is similar in `produce_events` and `produce_random_events`)
3. Possibly provide a different impl of things like #153 (though the existing one is quite simple so this is a weak motivation)

Opening up in draft for an early look (**still needs some cleanup**). This is my first foray into trait objects, so this PR only exists by the good graces of [crust of rust](https://www.youtube.com/watch?v=xcygqF5LVmM&list=PLqbS7AVVErFiWDOAVrPt7aYmnuuOLYvOa) / suggestions for more canonical rust ways of doing this are very welcome!