### PR TITLE
Issue #168: Adding optional start and count values to sim.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,31 @@ to execute. Note that `source` nodes *must* be contained in `nodes`,
 but destination nodes can be any public node in the network (though 
 this may result in liquidity draining over time).
 
+Required fields:
+```
+"source": the payer
+"destination": the payee
+"interval_secs": how often the payments should be sent
+"amount_msat": the amount of each payment
+```
+
+Optional fields:
+```
+"start_secs": the time to start sending payments
+"count": the total number of payments to send
+```
+
+> If `start_secs` is not provided the payments will begin as soon as the simulation starts (default=0)
+
+> If `count` is not provided the payments will continue for as long as the simulation runs (default=None)
+
 The example simulation file below sets up the following simulation:
 * Connect to `Alice` running LND to generate activity.
 * Connect to `Bob` running CLN to generate activity.
 * Dispatch 2000 msat payments from `Alice` to `Carol` every 1 seconds.
 * Dispatch 140000 msat payments from `Bob` to `Alice` every 50 seconds.
 * Dispatch 1000 msat payments from `Bob` to `Dave` every 2 seconds.
+* Dispatch 10 payments (5000 msat each) from `Erin` to `Frank` at 2 second intervals, starting 20 seconds into the sim.
 ```
 {
   "nodes": [
@@ -162,6 +181,18 @@ The example simulation file below sets up the following simulation:
       "ca_cert": "/path/ca.pem",
       "client_cert": "/path/client.pem",
       "client_key": "/path/client-key.pem"
+    },
+    {
+      "id": "Erin",
+      "address": "https://localhost:10012",
+      "macaroon": "/path/admin.macaroon",
+      "cert": "/path/tls.cert"      
+    },
+    {
+      "id": "Frank",
+      "address": "https://localhost:10014",
+      "macaroon": "/path/admin.macaroon",
+      "cert": "/path/tls.cert"      
     }
   ],
   "activity": [
@@ -182,6 +213,14 @@ The example simulation file below sets up the following simulation:
       "destination": "03232e245059a2e7f6e32d6c4bca97fc4cda935c553ea3693adb3265a19050c3bf",
       "interval_secs": 2,
       "amount_msat": 1000
+    },
+    {
+      "source": "Erin",
+      "destination": "Frank",
+      "start_secs": 20,
+      "count": 10,
+      "interval_secs": 2,
+      "amount_msat": 5000
     }
   ]
 }

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -185,6 +185,8 @@ async fn main() -> anyhow::Result<()> {
         validated_activities.push(ActivityDefinition {
             source,
             destination,
+            start_secs: act.start_secs,
+            count: act.count,
             interval_secs: act.interval_secs,
             amount_msat: act.amount_msat,
         });

--- a/sim-lib/src/defined_activity.rs
+++ b/sim-lib/src/defined_activity.rs
@@ -5,14 +5,24 @@ use tokio::time::Duration;
 #[derive(Clone)]
 pub struct DefinedPaymentActivity {
     destination: NodeInfo,
+    start: Duration,
+    count: Option<u64>,
     wait: Duration,
     amount: u64,
 }
 
 impl DefinedPaymentActivity {
-    pub fn new(destination: NodeInfo, wait: Duration, amount: u64) -> Self {
+    pub fn new(
+        destination: NodeInfo,
+        start: Duration,
+        count: Option<u64>,
+        wait: Duration,
+        amount: u64,
+    ) -> Self {
         DefinedPaymentActivity {
             destination,
+            start,
+            count,
             wait,
             amount,
         }
@@ -36,6 +46,14 @@ impl DestinationGenerator for DefinedPaymentActivity {
 }
 
 impl PaymentGenerator for DefinedPaymentActivity {
+    fn payment_start(&self) -> Duration {
+        self.start
+    }
+
+    fn payment_count(&self) -> Option<u64> {
+        self.count
+    }
+
     fn next_payment_wait(&self) -> Duration {
         self.wait
     }
@@ -69,8 +87,13 @@ mod tests {
         let source = get_random_keypair();
         let payment_amt = 50;
 
-        let generator =
-            DefinedPaymentActivity::new(node.clone(), Duration::from_secs(60), payment_amt);
+        let generator = DefinedPaymentActivity::new(
+            node.clone(),
+            Duration::from_secs(0),
+            None,
+            Duration::from_secs(60),
+            payment_amt,
+        );
 
         let (dest, dest_capacity) = generator.choose_destination(source.1);
         assert_eq!(node.pubkey, dest.pubkey);

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -50,7 +50,7 @@ impl NodeId {
             crate::NodeId::PublicKey(pk) => {
                 if pk != node_id {
                     return Err(LightningError::ValidationError(format!(
-                        "the provided node id does not match the one returned by the backend ({} != {}).",
+                        "The provided node id does not match the one returned by the backend ({} != {}).",
                         pk, node_id
                     )));
                 }
@@ -655,7 +655,7 @@ impl Simulation {
         // csr: consume simulation results
         let csr_write_results = self.write_results.clone();
         tasks.spawn(async move {
-            log::debug!("Staring simulation results consumer.");
+            log::debug!("Starting simulation results consumer.");
             if let Err(e) = consume_simulation_results(
                 result_logger,
                 results_receiver,
@@ -795,9 +795,9 @@ impl Simulation {
                     consume_events(ce_node, receiver, ce_output_sender, ce_listener).await
                 {
                     ce_shutdown.trigger();
-                    log::error!("Event consumer exited with error: {e:?}.");
+                    log::error!("Event consumer for node {node_info} exited with error: {e:?}.");
                 } else {
-                    log::debug!("Event consumer for node {node_info} received shutdown signal.");
+                    log::debug!("Event consumer for node {node_info} completed successfully.");
                 }
             });
         }
@@ -844,9 +844,9 @@ impl Simulation {
                 .await
                 {
                     pe_shutdown.trigger();
-                    log::debug!("Event producer exited with error {e}.");
+                    log::debug!("Activity producer for {source} exited with error {e}.");
                 } else {
-                    log::debug!("Random activity generator for {source} received shutdown signal.");
+                    log::debug!("Activity producer for {source} completed successfully.");
                 }
             });
         }
@@ -940,7 +940,7 @@ async fn produce_events<N: DestinationGenerator + ?Sized, A: PaymentGenerator + 
     loop {
         if let Some(c) = node_generator.payment_count() {
             if c == current_count {
-                log::info!("Payment count has been met: {c} payments. Stopping the activity.");
+                log::info!("Payment count has been met for {source}: {c} payments. Stopping the activity.");
                 return Ok(());
             }
         }
@@ -979,12 +979,12 @@ async fn produce_events<N: DestinationGenerator + ?Sized, A: PaymentGenerator + 
                     },
                 };
 
-                log::debug!("Generated random payment: {source} -> {}: {amount} msat.", destination);
+                log::debug!("Generated payment: {source} -> {}: {amount} msat.", destination);
 
                 // Send the payment, exiting if we can no longer send to the consumer.
                 let event = SimulationEvent::SendPayment(destination.clone(), amount);
                 if sender.send(event.clone()).await.is_err() {
-                    return Err(SimulationError::MpscChannelError (format!("Stopped random producer for {amount}: {source} -> {destination}.")));
+                    return Err(SimulationError::MpscChannelError (format!("Stopped activity producer for {amount}: {source} -> {destination}.")));
                 }
 
                 current_count += 1;

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -964,16 +964,21 @@ async fn produce_events<N: DestinationGenerator + ?Sized, A: PaymentGenerator + 
         }
 
         let wait: Duration = if current_count == 0 {
-            log::debug!(
-                "Using a start delay. The first payment for {source} will be at {:?} seconds.",
-                node_generator.payment_start()
-            );
-            node_generator.payment_start()
+            let start = node_generator.payment_start();
+            if start != Duration::from_secs(0) {
+                log::debug!(
+                    "Using a start delay. The first payment for {source} will be at {:?}.",
+                    start
+                );
+            }
+            start
         } else {
+            log::debug!(
+                "Next payment for {source} in {:?}.",
+                node_generator.next_payment_wait()
+            );
             node_generator.next_payment_wait()
         };
-
-        log::debug!("Next payment for {source} in {:?} seconds.", wait);
 
         select! {
             biased;

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -940,7 +940,9 @@ async fn produce_events<N: DestinationGenerator + ?Sized, A: PaymentGenerator + 
     loop {
         if let Some(c) = node_generator.payment_count() {
             if c == current_count {
-                log::info!("Payment count has been met for {source}: {c} payments. Stopping the activity.");
+                log::info!(
+                    "Payment count has been met for {source}: {c} payments. Stopping the activity."
+                );
                 return Ok(());
             }
         }

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -194,6 +194,16 @@ fn events_per_month(source_capacity_msat: u64, multiplier: f64, expected_payment
 }
 
 impl PaymentGenerator for RandomPaymentActivity {
+    /// Returns the time that the payments should start
+    fn payment_start(&self) -> Duration {
+        Duration::from_secs(0)
+    }
+
+    /// Returns the number of payments that should be made
+    fn payment_count(&self) -> Option<u64> {
+        None
+    }
+
     /// Returns the amount of time until the next payment should be scheduled for the node.
     fn next_payment_wait(&self) -> Duration {
         let mut rng = rand::thread_rng();

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -194,12 +194,12 @@ fn events_per_month(source_capacity_msat: u64, multiplier: f64, expected_payment
 }
 
 impl PaymentGenerator for RandomPaymentActivity {
-    /// Returns the time that the payments should start
+    /// Returns the time that the payments should start. This will always be 0 for the RandomPaymentActivity type.
     fn payment_start(&self) -> Duration {
         Duration::from_secs(0)
     }
 
-    /// Returns the number of payments that should be made
+    /// Returns the number of payments that should be made. This will always be None for the RandomPaymentActivity type.
     fn payment_count(&self) -> Option<u64> {
         None
     }


### PR DESCRIPTION
Adding `start` and `count` options to the sim.json file.

`start`: Specifies when in the simulation the user wants this activity to start (for example... start sending payments at 10s)
`count`: Specifies the number of payments to send throughout the simulation (for example... send 15 payments and then stop)

Resolves #168 