### PR TITLE
sim_network: Add unit tests + squash bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +540,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -952,6 +964,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "mpsc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1188,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1713,6 +1778,7 @@ dependencies = [
  "hex",
  "lightning",
  "log",
+ "mockall",
  "mpsc",
  "ntest",
  "rand",
@@ -1840,6 +1906,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -29,6 +29,7 @@ hex = "0.4.3"
 csv = "1.2.2"
 serde_millis = "0.1.1"
 rand_distr = "0.4.3"
+mockall = "0.12.1"
 
 [dev-dependencies]
 ntest = "0.9.0"

--- a/sim-lib/src/sim_node.rs
+++ b/sim-lib/src/sim_node.rs
@@ -894,7 +894,7 @@ async fn remove_htlcs(
     payment_hash: PaymentHash,
     success: bool,
 ) -> Result<(), ForwardingError> {
-    for (i, hop) in route.hops[0..resolution_idx].iter().enumerate().rev() {
+    for (i, hop) in route.hops[0..=resolution_idx].iter().enumerate().rev() {
         // When we add HTLCs, we do so on the state of the node that sent the htlc along the channel so we need to
         // look up our incoming node so that we can remove it when we go backwards. For the first htlc, this is just
         // the sending node, otherwise it's the hop before.
@@ -967,8 +967,15 @@ async fn propagate_payment(
         }
     } else {
         // If we successfully added the htlc, go ahead and remove all the htlcs in the route with successful resolution.
-        if let Err(e) =
-            remove_htlcs(nodes, route.hops.len(), source, route, payment_hash, true).await
+        if let Err(e) = remove_htlcs(
+            nodes,
+            route.hops.len() - 1,
+            source,
+            route,
+            payment_hash,
+            true,
+        )
+        .await
         {
             if e.is_critical() {
                 shutdown.trigger();


### PR DESCRIPTION
This PR adds coverage for our simulated network and (unsurprisingly) squashes some bugs: 
* Do not double-return liquidity for failed HTLCs: previously we'd return liquidity to local balance on failures twice over
* Off by one removal: if a HTLC failed at index 0, we would not remove the first HTLC because our loop was not running for `=0`.

Removal bugs not caught in original testing because we evenly distribute liquidity, so didn't run into any payment failure - going to set liquidity to zero and re-run for a while to see if anything falls apart. 