### PR TITLE
Update method parameter to take reference to PaymentHash

### DIFF
--- a/sim-lib/src/cln.rs
+++ b/sim-lib/src/cln.rs
@@ -188,7 +188,7 @@ impl LightningNode for ClnNode {
 
     async fn track_payment(
         &mut self,
-        hash: PaymentHash,
+        hash: &PaymentHash,
         shutdown: Listener,
     ) -> Result<PaymentResult, LightningError> {
         loop {

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -250,7 +250,7 @@ pub trait LightningNode: Send {
     /// Track a payment with the specified hash.
     async fn track_payment(
         &mut self,
-        hash: PaymentHash,
+        hash: &PaymentHash,
         shutdown: Listener,
     ) -> Result<PaymentResult, LightningError>;
     /// Gets information on a specific node
@@ -1214,7 +1214,7 @@ async fn track_payment_result(
     let res = match payment.hash {
         Some(hash) => {
             log::debug!("Tracking payment outcome for: {}.", hex::encode(hash.0));
-            let track_payment = node.track_payment(hash, listener.clone());
+            let track_payment = node.track_payment(&hash, listener.clone());
 
             match track_payment.await {
                 Ok(res) => {

--- a/sim-lib/src/lnd.rs
+++ b/sim-lib/src/lnd.rs
@@ -175,7 +175,7 @@ impl LightningNode for LndNode {
 
     async fn track_payment(
         &mut self,
-        hash: PaymentHash,
+        hash: &PaymentHash,
         shutdown: Listener,
     ) -> Result<PaymentResult, LightningError> {
         let response = self

--- a/sim-lib/src/sim_node.rs
+++ b/sim-lib/src/sim_node.rs
@@ -557,10 +557,10 @@ impl<T: SimNetwork> LightningNode for SimNode<'_, T> {
     /// provided is triggered. This call will fail if the hash provided was not obtained by calling send_payment first.
     async fn track_payment(
         &mut self,
-        hash: PaymentHash,
+        hash: &PaymentHash,
         listener: Listener,
     ) -> Result<PaymentResult, LightningError> {
-        match self.in_flight.remove(&hash) {
+        match self.in_flight.remove(hash) {
             Some(receiver) => {
                 select! {
                     biased;
@@ -1491,13 +1491,13 @@ mod tests {
         let (_, shutdown_listener) = triggered::trigger();
 
         let result_1 = node
-            .track_payment(hash_1, shutdown_listener.clone())
+            .track_payment(&hash_1, shutdown_listener.clone())
             .await
             .unwrap();
         assert!(matches!(result_1.payment_outcome, PaymentOutcome::Success));
 
         let result_2 = node
-            .track_payment(hash_2, shutdown_listener.clone())
+            .track_payment(&hash_2, shutdown_listener.clone())
             .await
             .unwrap();
         assert!(matches!(


### PR DESCRIPTION
This PR updates the `track_payment` method in the `LightningNode` trait to accept a reference to PaymentHash instead of taking ownership

- Changed method signature to `&PaymentHash` in the `LightningNode` trait.
- Updated all implementations and usages of `track_payment` accordingly.