### PR TITLE
Validate zero amount in a defined activity 

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -475,6 +475,12 @@ impl Simulation {
         }
 
         for payment_flow in self.activity.iter() {
+            // lets validate the amount_msats to be greater than zero
+            if payment_flow.amount_msat==0 {
+                return Err(LightningError::ValidationError(
+                    "Expected amount_msat should be greater than zero.".to_string(),
+                ));
+            }
             // We need every source node that is configured to execute some activity to be included in our set of
             // nodes so that we can execute events on it.
             self.nodes

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -475,12 +475,6 @@ impl Simulation {
         }
 
         for payment_flow in self.activity.iter() {
-            // lets validate the amount_msats to be greater than zero
-            if payment_flow.amount_msat==0 {
-                return Err(LightningError::ValidationError(
-                    "Expected amount_msat should be greater than zero.".to_string(),
-                ));
-            }
             // We need every source node that is configured to execute some activity to be included in our set of
             // nodes so that we can execute events on it.
             self.nodes
@@ -497,6 +491,12 @@ impl Simulation {
                     "Destination node does not support keysend, {}",
                     payment_flow.destination,
                 )));
+            }
+            // lets validate the amount_msats to be greater than zero
+            if payment_flow.amount_msat == 0 {
+                return Err(LightningError::ValidationError(
+                    "Expected amount_msat should be greater than zero.".to_string(),
+                ));
             }
         }
 


### PR DESCRIPTION
This PR addresses the issue #176 . This has been done by updating the validate_activity function 

- updated [validate_activity](https://github.com/bitcoin-dev-project/sim-ln/blob/main/sim-lib/src/lib.rs#L457) to disallow zero values.
- Throws a validation error when amount_msat is 0 on a defined activity