### PR TITLE
workflows: pin clippy version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,11 @@ jobs:
       - name: Install protoc
         run: sudo apt install -y protobuf-compiler
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.76.0
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Install Rustfmt
+        run: rustup component add rustfmt
       - name: run check
         run: make check
 


### PR DESCRIPTION
Pin the version of clippy that we use in CI so that new releases don't break existing CI.

Testing to see whether installing clippy at a set version will help.