### PR TITLE
sim-lib: only use start delay if explicitly specified

### DIFF
--- a/sim-lib/src/defined_activity.rs
+++ b/sim-lib/src/defined_activity.rs
@@ -8,7 +8,7 @@ use tokio::time::Duration;
 #[derive(Clone)]
 pub struct DefinedPaymentActivity {
     destination: NodeInfo,
-    start: Duration,
+    start: Option<Duration>,
     count: Option<u64>,
     wait: ValueOrRange<u16>,
     amount: ValueOrRange<u64>,
@@ -17,7 +17,7 @@ pub struct DefinedPaymentActivity {
 impl DefinedPaymentActivity {
     pub fn new(
         destination: NodeInfo,
-        start: Duration,
+        start: Option<Duration>,
         count: Option<u64>,
         wait: ValueOrRange<u16>,
         amount: ValueOrRange<u64>,
@@ -52,7 +52,7 @@ impl DestinationGenerator for DefinedPaymentActivity {
 }
 
 impl PaymentGenerator for DefinedPaymentActivity {
-    fn payment_start(&self) -> Duration {
+    fn payment_start(&self) -> Option<Duration> {
         self.start
     }
 
@@ -81,7 +81,6 @@ impl PaymentGenerator for DefinedPaymentActivity {
 #[cfg(test)]
 mod tests {
     use super::DefinedPaymentActivity;
-    use super::*;
     use crate::test_utils::{create_nodes, get_random_keypair};
     use crate::{DestinationGenerator, PaymentGenerationError, PaymentGenerator};
 
@@ -95,7 +94,7 @@ mod tests {
 
         let generator = DefinedPaymentActivity::new(
             node.clone(),
-            Duration::from_secs(0),
+            None,
             None,
             crate::ValueOrRange::Value(60),
             crate::ValueOrRange::Value(payment_amt),

--- a/sim-lib/src/random_activity.rs
+++ b/sim-lib/src/random_activity.rs
@@ -214,8 +214,8 @@ fn events_per_month(source_capacity_msat: u64, multiplier: f64, expected_payment
 
 impl PaymentGenerator for RandomPaymentActivity {
     /// Returns the time that the payments should start. This will always be 0 for the RandomPaymentActivity type.
-    fn payment_start(&self) -> Duration {
-        Duration::from_secs(0)
+    fn payment_start(&self) -> Option<Duration> {
+        None
     }
 
     /// Returns the number of payments that should be made. This will always be None for the RandomPaymentActivity type.


### PR DESCRIPTION
As is, we'll run with a 0 second start delay for:
- Random activities
- Defined activities with no `start_secs` specified

This very likely isn't the intent for defined activities (people should set `start_secs=0` if they want their payments to fire immediately), and doesn't work for random activity because we just fire all payments on start.

Instead, we switch over to using our payment wait as the start delay in the absence of this field being set for defined activities and always for random activities.

Fixes #189