### PR TITLE
chore(rng): clean up documentation and RNG type

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ of the random activity that is generated:
      capacity in a month.
   * `capacity-multiplier=0.5` means that each node sends half their 
     capacity in a month.
-* `--fix-seed`: a `u64` value that allows you to generate random activities deterministically from the provided seed, albeit with some limitations. The  simulations are not guaranteed to be perfectly deterministic because tasks complete in slightly different orders on each run of the simulator. With a fixed seed, we can guarantee that the order in which activities are dispatched will be deterministic.
+* `--fix-seed`: a `u64` value that allows you to generate random activities 
+  deterministically from the provided seed, albeit with some limitations. 
+  The simulations are not guaranteed to be perfectly deterministic because 
+  tasks complete in slightly different orders on each run of the simulator. 
+  With a fixed seed, we can guarantee that the order in which activities are
+  dispatched will be deterministic.
 
 ### Setup - Defined Activity
 If you would like SimLN to generate a specific payments between source 

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -453,12 +453,12 @@ enum SimulationOutput {
 ///
 /// **Note**: `StdMutex`, i.e. (`std::sync::Mutex`), is used here to avoid making the traits
 /// `DestinationGenerator` and `PaymentGenerator` async.
-type MutRngType = Arc<StdMutex<Box<dyn RngCore + Send>>>;
+type MutRngType = Arc<StdMutex<dyn RngCore + Send>>;
 
 /// Newtype for `MutRngType` to encapsulate and hide implementation details for
 /// creating new `MutRngType` types. Provides convenient API for the same purpose.
 #[derive(Clone)]
-struct MutRng(pub MutRngType);
+struct MutRng(MutRngType);
 
 impl MutRng {
     /// Creates a new MutRng given an optional `u64` argument. If `seed_opt` is `Some`,
@@ -467,11 +467,9 @@ impl MutRng {
     /// non-deterministic source of entropy.
     pub fn new(seed_opt: Option<u64>) -> Self {
         if let Some(seed) = seed_opt {
-            Self(Arc::new(StdMutex::new(
-                Box::new(ChaCha8Rng::seed_from_u64(seed)) as Box<dyn RngCore + Send>,
-            )))
+            Self(Arc::new(StdMutex::new(ChaCha8Rng::seed_from_u64(seed))))
         } else {
-            Self(Arc::new(StdMutex::new(Box::new(StdRng::from_entropy()))))
+            Self(Arc::new(StdMutex::new(StdRng::from_entropy())))
         }
     }
 }


### PR DESCRIPTION
## What this PR does
- Follows up on #178 
- Fixes documentation nits and line length
- Updates the visibility specifier in `MutRng` and removes unnecessary `Box`ing in `MutRngType`