### PR TITLE
simln-lib/feat: Parse address detecting if starts with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ information is required:
 ```
 {
   "id": <node_id>,
-  "address": https://<ip:port or domain:port>,
+  "address": <ip:port or domain:port>,
   "macaroon": <path_to_selected_macaroon>,
   "cert": <path_to_tls_cert>
 }
@@ -74,14 +74,13 @@ Whereas for CLN nodes, the following information is required:
 ```
 { 
   "id": <node_id>,
-  "address": https://<ip:port or domain:port>,
+  "address": <ip:port or domain:port>,
   "ca_cert": <path_to_ca_cert>,
   "client_cert": <path_to_client_cert>,
   "client_key": <path_to_client_key>
 }
 ```
 
-**Note that node addresses must be declare with HTTPS transport, i.e. <https://ip-or-domain:port>**
 
 Payment activity can be simulated in two different ways:
 * Random activity: generate random activity on the `nodes` provided, 
@@ -102,13 +101,13 @@ not "drain" from the simulation.
   "nodes": [
     {
       "id": "Alice",
-      "address": "https://127.0.0.1:10011",
+      "address": "127.0.0.1:10011",
       "macaroon": "/path/admin.macaroon",
       "cert": "/path/tls.cert"
     },
     { 
       "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
-      "address": "https://localhost:10013",
+      "address": "localhost:10013",
       "ca_cert": "/path/ca.pem",
       "client_cert": "/path/client.pem",
       "client_key": "/path/client-key.pem"
@@ -177,26 +176,26 @@ The example simulation file below sets up the following simulation:
   "nodes": [
     {
       "id": "Alice",
-      "address": "https://localhost:10011",
+      "address": "localhost:10011",
       "macaroon": "/path/admin.macaroon",
       "cert": "/path/tls.cert"
     },
     {
       "id": "0230a16a05c5ca120136b3a770a2adfdad88a68d526e63448a9eef88bddd6a30d8",
-      "address": "https://127.0.0.1:10013",
+      "address": "127.0.0.1:10013",
       "ca_cert": "/path/ca.pem",
       "client_cert": "/path/client.pem",
       "client_key": "/path/client-key.pem"
     },
     {
       "id": "Erin",
-      "address": "https://localhost:10012",
+      "address": "localhost:10012",
       "macaroon": "/path/admin.macaroon",
       "cert": "/path/tls.cert"      
     },
     {
       "id": "Frank",
-      "address": "https://localhost:10014",
+      "address": "localhost:10014",
       "macaroon": "/path/admin.macaroon",
       "cert": "/path/tls.cert"      
     }
@@ -232,7 +231,6 @@ The example simulation file below sets up the following simulation:
 }
 ```
 
-**Note that node addresses must be declare with HTTPS transport, i.e <https://ip-or-domain>**
 
 Nodes can be identified by their public key or an id string (as 
 described above). Activity sources and destinations may reference the 

--- a/simln-lib/src/cln.rs
+++ b/simln-lib/src/cln.rs
@@ -24,6 +24,7 @@ use crate::{
 pub struct ClnConnection {
     #[serde(with = "serializers::serde_node_id")]
     pub id: NodeId,
+    #[serde(with = "serializers::serde_address")]
     pub address: String,
     #[serde(deserialize_with = "serializers::deserialize_path")]
     pub ca_cert: String,
@@ -57,7 +58,7 @@ impl ClnNode {
             ));
 
         let mut client = NodeClient::new(
-            Channel::from_shared(connection.address.to_string())
+            Channel::from_shared(connection.address)
                 .map_err(|err| LightningError::ConnectionError(err.to_string()))?
                 .tls_config(tls)
                 .map_err(|_| {

--- a/simln-lib/src/lnd.rs
+++ b/simln-lib/src/lnd.rs
@@ -26,6 +26,7 @@ const SEND_PAYMENT_TIMEOUT_SECS: i32 = 300;
 pub struct LndConnection {
     #[serde(with = "serializers::serde_node_id")]
     pub id: NodeId,
+    #[serde(with = "serializers::serde_address")]
     pub address: String,
     #[serde(deserialize_with = "serializers::deserialize_path")]
     pub macaroon: String,

--- a/simln-lib/src/serializers.rs
+++ b/simln-lib/src/serializers.rs
@@ -45,6 +45,29 @@ pub mod serde_node_id {
     }
 }
 
+pub mod serde_address {
+    use super::*;
+
+    pub fn serialize<S>(address: &str, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(address)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.starts_with("https://") {
+            Ok(s)
+        } else {
+            Ok(format!("https://{}", s))
+        }
+    }
+}
+
 pub mod serde_value_or_range {
     use super::*;
     use serde::{de::Error, ser::SerializeTuple};


### PR DESCRIPTION
fix #154 
Detect if the parsed address starts with the https protocol; if not, add it without requiring a user to do it.