### PR TITLE
Prevent Memory Buildup by Clearing Joinsets

### DIFF
--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -817,6 +817,14 @@ impl SimNetwork for SimGraph {
             },
         };
 
+        // This fixes it, but is a super weird way to do this!
+        while let Some(res) = self.tasks.try_join_next() {
+            if let Err(e) = res {
+                log::error!("Error completing task {e}");
+                self.shutdown_trigger.trigger();
+            }
+        }
+
         self.tasks.spawn(propagate_payment(
             self.channels.clone(),
             source,


### PR DESCRIPTION
TIL that the memory for a task spawned in a joinset will not be released until its corresponding entry in the joinset is consumed ❗ ❗ 

This means that the pattern that we currently use of spawning a bunch of tasks then waiting on the joinset at the end of the simulation results in massive memory blowup over time, because we never free the memory from out completed tasks.

Created this PR while diagnosing this issue, and opening it up so that it's available if anyone needs a quickndirty fix. 
This can and should be done in a slightly neater way!