### PR TITLE
sim-cli/bug: Interaction between simulation file path and results directory

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -233,16 +233,18 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn read_sim_path(data_dir: PathBuf, sim_file: PathBuf) -> anyhow::Result<PathBuf> {
-    let sim_path = if sim_file.is_relative() {
-        data_dir.join(sim_file)
+    if sim_file.exists() {
+        Ok(sim_file)
+    } else if sim_file.is_relative() {
+        let sim_path = data_dir.join(sim_file);
+        if sim_path.exists() {
+            Ok(sim_path)
+        } else {
+            log::info!("Simulation file '{}' does not exist.", sim_path.display());
+            select_sim_file(data_dir).await
+        }
     } else {
-        sim_file
-    };
-
-    if sim_path.exists() {
-        Ok(sim_path)
-    } else {
-        log::info!("Simulation file '{}' does not exist.", sim_path.display());
+        log::info!("Simulation file '{}' does not exist.", sim_file.display());
         select_sim_file(data_dir).await
     }
 }


### PR DESCRIPTION
Addressing https://github.com/bitcoin-dev-project/sim-ln/issues/217
Logic:
1. If sim file is present (absolute or relative, doesn't matter) - use it.
2. If it's not present as it is - fallback to the current behaviour:
     a. try to join with data_dir, if it's present -great
     b. if it's not present - fallback to datadir lookup
3. If it's neither present of relative path - fallback to datadir lookup.