### PR TITLE
fix memory buildup from JoinSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,7 @@ dependencies = [
  "simln-lib",
  "simple_logger",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2107,6 +2108,7 @@ dependencies = [
  "serde_millis",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic 0.8.3",
  "triggered",
 ]
@@ -2374,6 +2376,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]

--- a/sim-cli/Cargo.toml
+++ b/sim-cli/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.5"
 hex = {version = "0.4.3"}
 futures = "0.3.30"
 console-subscriber = { version = "0.4.0", optional = true}
+tokio-util = { version = "0.7.13", features = ["rt"] }
 
 [features]
 dev = ["console-subscriber"]

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio_util::task::TaskTracker;
 
 /// The default directory where the simulation files are stored and where the results will be written to.
 pub const DEFAULT_DATA_DIR: &str = ".";
@@ -209,6 +210,7 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
+    let tasks = TaskTracker::new();
     let sim = Simulation::new(
         SimulationCfg::new(
             cli.total_time,
@@ -219,6 +221,7 @@ async fn main() -> anyhow::Result<()> {
         ),
         clients,
         validated_activities,
+        tasks,
     );
     let sim2 = sim.clone();
 

--- a/simln-lib/Cargo.toml
+++ b/simln-lib/Cargo.toml
@@ -32,6 +32,7 @@ serde_millis = "0.1.1"
 rand_distr = "0.4.3"
 mockall = "0.12.1"
 rand_chacha = "0.3.1"
+tokio-util = { version = "0.7.13", features = ["rt"] }
 
 [dev-dependencies]
 ntest = "0.9.0"


### PR DESCRIPTION
I ended up taking a different approach from what I mentioned here https://github.com/bitcoin-dev-project/sim-ln/pull/221#issuecomment-2707278793 to fix the memory buildup.

This adds a new dependency `tokio-util` but since it's from tokio which is already used, I though it would be ok. If not, let me know and I can try something else. 

It uses a `TaskTracker` from `tokio-util` which works very similar to a `JoinSet` but with the difference that it will free the memory from tasks when they are finished without having to call something like `join_next` for a `JoinSet`.

From their docs https://docs.rs/tokio-util/latest/tokio_util/task/task_tracker/struct.TaskTracker.html#comparison-to-joinset: 

> A [JoinSet](https://docs.rs/tokio/1.43.0/x86_64-unknown-linux-gnu/tokio/task/join_set/struct.JoinSet.html) keeps track of the return value of every inserted task. This means that if the caller keeps inserting tasks and never calls [join_next](https://docs.rs/tokio/1.43.0/x86_64-unknown-linux-gnu/tokio/task/join_set/struct.JoinSet.html#method.join_next), then their return values will keep building up and consuming memory, even if most of the tasks have already exited. This can cause the process to run out of memory. With a TaskTracker, this does not happen. Once tasks exit, they are immediately removed from the TaskTracker.

I tested it with the scenario from here: https://github.com/carlaKC/sim-ln/tree/review-club-memleak and it's avoiding the memory buildup that was happening with the `JoinSet`. 