### PR TITLE
Update CI Rust Version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install protoc
         run: sudo apt install -y protobuf-compiler
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - name: Install Clippy
         run: rustup component add clippy
       - name: Install Rustfmt


### PR DESCRIPTION
This PR aims to update the Rust version on the CI specifically to enable the use of async closures which is now a stable feature on this version.