### PR TITLE
Unit tests for validate_activity and validate_node_network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,21 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
+ "mockall_derive 0.12.1",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive 0.13.1",
  "predicates",
  "predicates-tree",
 ]
@@ -1531,6 +1545,18 @@ name = "mockall_derive"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -2546,7 +2572,8 @@ dependencies = [
  "hex",
  "lightning",
  "log",
- "mockall",
+ "mockall 0.12.1",
+ "mockall 0.13.1",
  "mpsc",
  "ntest",
  "rand",

--- a/simln-lib/Cargo.toml
+++ b/simln-lib/Cargo.toml
@@ -37,3 +37,4 @@ tokio-util = { version = "0.7.13", features = ["rt"] }
 
 [dev-dependencies]
 ntest = "0.9.0"
+mockall = "0.13.1"

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -1460,6 +1460,7 @@ mod tests {
         PaymentGenerationError, PaymentGenerator, Simulation,
     };
     use async_trait::async_trait;
+    use bitcoin::Network;
     use bitcoin::secp256k1::PublicKey;
     use mockall::mock;
     use std::collections::HashMap;
@@ -1586,33 +1587,264 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_validate_zero_amount_no_valid() {
-        let nodes = test_utils::create_nodes(2, 100_000);
-        let mut node_1 = nodes.first().unwrap().0.clone();
-        let mut node_2 = nodes.get(1).unwrap().0.clone();
-        node_1.features.set_keysend_optional();
-        node_2.features.set_keysend_optional();
-
-        let mock_node_1 = MockLightningNode::new();
-        let mock_node_2 = MockLightningNode::new();
+    /// Creates a set of nodes with mock implementations
+    fn setup_test_nodes(node_count: usize, keysend_indices: &[usize]) -> (
+        Vec<NodeInfo>,
+        HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>
+    ) {
+        let nodes = test_utils::create_nodes(node_count, 100_000);
+        let mut node_infos = Vec::new();
         let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> = HashMap::new();
-        clients.insert(node_1.pubkey, Arc::new(Mutex::new(mock_node_1)));
-        clients.insert(node_2.pubkey, Arc::new(Mutex::new(mock_node_2)));
-        let activity_definition = crate::ActivityDefinition {
-            source: node_1,
-            destination: node_2,
-            start_secs: None,
-            count: None,
-            interval_secs: crate::ValueOrRange::Value(0),
-            amount_msat: crate::ValueOrRange::Value(0),
-        };
-        let simulation = Simulation::new(
+        
+        for (idx, (node_info, _)) in nodes.into_iter().enumerate() {
+            let mut node = node_info.clone();
+            
+            // Enable keysend on specified nodes
+            if keysend_indices.contains(&idx) {
+                node.features.set_keysend_optional();
+            }
+            
+            // Create and configure mock
+            let mut mock_node = MockLightningNode::new();
+            mock_node.expect_get_info().return_const(node.clone());
+            
+            // Store in map
+            clients.insert(node.pubkey, Arc::new(Mutex::new(mock_node)));
+            node_infos.push(node);
+        }
+        
+        (node_infos, clients)
+    }
+
+    /// Creates a simulation with the given nodes and activity
+    fn create_simulation(
+        clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>,
+        activity: Vec<crate::ActivityDefinition>
+    ) -> Simulation {
+        Simulation::new(
             crate::SimulationCfg::new(Some(0), 0, 0.0, None, None),
             clients,
-            vec![activity_definition],
+            activity,
             TaskTracker::new(),
-        );
-        assert!(simulation.validate_activity().await.is_err());
+        )
+    }
+
+    /// Creates an activity definition
+    fn create_activity(
+        source: NodeInfo,
+        destination: NodeInfo,
+        amount_msat: u64
+    ) -> crate::ActivityDefinition {
+        crate::ActivityDefinition {
+            source,
+            destination,
+            start_secs: None,
+            count: None,
+            interval_secs: crate::ValueOrRange::Value(5),
+            amount_msat: crate::ValueOrRange::Value(amount_msat),
+        }
+    }
+
+    /// Tests for validate_activity() 
+    #[tokio::test]
+    async fn test_validate_activity_empty_with_sufficient_nodes() {
+        // Create two nodes, both with keysend support
+        let (_, clients) = setup_test_nodes(2, &[0, 1]);
+        
+        // Create simulation with empty activity (for random generation)
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_activity_empty_with_insufficient_nodes() {
+        // Create just one node with keysend support
+        let (_, clients) = setup_test_nodes(1, &[0]);
+        
+        // Create simulation with empty activity (for random generation)
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("At least two nodes required")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_activity_empty_with_non_keysend_node() {
+        // Create two nodes, but only one with keysend
+        let (_, clients) = setup_test_nodes(2, &[0]);
+        
+        // Create simulation with empty activity (for random generation)
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("must support keysend")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_activity_with_missing_source_node() {
+        // Create one node with keysend
+        let (nodes, clients) = setup_test_nodes(1, &[0]);
+        
+        // Create an additional node that isn't in our clients map
+        let missing_nodes = test_utils::create_nodes(1, 100_000);
+        let missing_node = missing_nodes.first().unwrap().0.clone();
+        
+        // Get a valid destination node
+        let dest_node = nodes[0].clone();
+        
+        // Create activity with missing source node
+        let activity = create_activity(missing_node, dest_node, 1000);
+        
+        let simulation = create_simulation(clients, vec![activity]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("Source node not found")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_activity_with_non_keysend_destination() {
+        // Create one node with keysend
+        let (nodes, clients) = setup_test_nodes(1, &[0]);
+        
+        // Create a destination node without keysend
+        let dest_nodes = test_utils::create_nodes(1, 100_000);
+        let dest_node = dest_nodes.first().unwrap().0.clone();
+        // Intentionally not setting keysend for destination
+        
+        // Create activity with non-keysend destination
+        let activity = create_activity(nodes[0].clone(), dest_node, 1000);
+        
+        let simulation = create_simulation(clients, vec![activity]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("does not support keysend")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_activity_valid_payment_flow() {
+        // Create one node with keysend
+        let (nodes, clients) = setup_test_nodes(1, &[0]);
+        
+        // Create a destination node with keysend
+        let dest_nodes = test_utils::create_nodes(1, 100_000);
+        let mut dest_node = dest_nodes.first().unwrap().0.clone();
+        dest_node.features.set_keysend_optional();
+        
+        // Create valid activity
+        let activity = create_activity(nodes[0].clone(), dest_node, 1000);
+        
+        let simulation = create_simulation(clients, vec![activity]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_zero_amount_no_valid() {
+        // Create two nodes with keysend
+        let (nodes, clients) = setup_test_nodes(2, &[0, 1]);
+        
+        // Create activity with zero amount
+        let activity = create_activity(nodes[0].clone(), nodes[1].clone(), 0);
+        
+        let simulation = create_simulation(clients, vec![activity]);
+        
+        let result = simulation.validate_activity().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("zero values")));
+    }
+
+    /// tests for validate_node_network()
+    fn setup_network_test_nodes(
+        node_count: usize, 
+        networks: Vec<Network>
+    ) -> HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> {
+        assert_eq!(node_count, networks.len(), "Must specify a network for each node");
+        
+        let nodes = test_utils::create_nodes(node_count, 100_000);
+        let mut clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> = HashMap::new();
+        
+        for (idx, (node_info, _)) in nodes.into_iter().enumerate() {
+            let mut mock_node = MockLightningNode::new();
+            
+            // Configure get_info to return the node info
+            mock_node.expect_get_info().return_const(node_info.clone());
+            
+            // Configure get_network to return the specified network
+            let network = networks[idx];
+            mock_node.expect_get_network().returning(move || Ok(network));
+            
+            // Store in map
+            clients.insert(node_info.pubkey, Arc::new(Mutex::new(mock_node)));
+        }
+        
+        clients
+    }
+
+    #[tokio::test]
+    async fn test_validate_node_network_empty_nodes() {
+        // Create simulation with empty nodes map
+        let empty_nodes: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> = HashMap::new();
+        let simulation = create_simulation(empty_nodes, vec![]);
+        
+        let result = simulation.validate_node_network().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("we don't control any nodes")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_node_network_mainnet_not_supported() {
+        // Create a node on mainnet (Bitcoin network)
+        let clients = setup_network_test_nodes(1, vec![Network::Bitcoin]);
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_node_network().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("mainnet is not supported")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_node_network_mixed_networks() {
+        // Create nodes on different networks (testnet and regtest)
+        let clients = setup_network_test_nodes(2, vec![Network::Testnet, Network::Regtest]);
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_node_network().await;
+        assert!(result.is_err());
+        assert!(matches!(result, 
+            Err(LightningError::ValidationError(msg)) if msg.contains("nodes are not on the same network")));
+    }
+
+    #[tokio::test]
+    async fn test_validate_node_network_multiple_nodes_same_network() {
+        // Create multiple nodes on the same network (testnet)
+        let clients = setup_network_test_nodes(3, vec![Network::Testnet, Network::Testnet, Network::Testnet]);
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_node_network().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_node_network_single_node_valid_network() {
+        // Create a single node on a valid network (testnet)
+        let clients = setup_network_test_nodes(1, vec![Network::Testnet]);
+        let simulation = create_simulation(clients, vec![]);
+        
+        let result = simulation.validate_node_network().await;
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
Based on this [issue](https://github.com/bitcoin-dev-project/sim-ln/issues/185), unit tests for methods `validate_activity` and `validate_node_network` in `simln-lib/src/lib.rs` were created. 