### PR TITLE
sim-lib: add simulated clock to speed up simulations

### DIFF
--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -3,6 +3,7 @@ use bitcoin::secp256k1::PublicKey;
 use clap::{builder::TypedValueParser, Parser};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
+use simln_lib::clock::SimulationClock;
 use simln_lib::sim_node::{
     ln_node_from_graph, populate_network_graph, ChannelPolicy, SimGraph, SimulatedChannel,
 };
@@ -198,7 +199,7 @@ pub async fn create_simulation_with_network(
     cli: &Cli,
     sim_params: &SimParams,
     tasks: TaskTracker,
-) -> Result<(Simulation, Vec<ActivityDefinition>), anyhow::Error> {
+) -> Result<(Simulation<SimulationClock>, Vec<ActivityDefinition>), anyhow::Error> {
     let cfg: SimulationCfg = SimulationCfg::try_from(cli)?;
     let SimParams {
         nodes: _,
@@ -241,7 +242,14 @@ pub async fn create_simulation_with_network(
         get_validated_activities(&nodes, nodes_info, sim_params.activity.clone()).await?;
 
     Ok((
-        Simulation::new(cfg, nodes, tasks, shutdown_trigger, shutdown_listener),
+        Simulation::new(
+            cfg,
+            nodes,
+            tasks,
+            Arc::new(SimulationClock::new(1)?),
+            shutdown_trigger,
+            shutdown_listener,
+        ),
         validated_activities,
     ))
 }
@@ -252,7 +260,7 @@ pub async fn create_simulation(
     cli: &Cli,
     sim_params: &SimParams,
     tasks: TaskTracker,
-) -> Result<(Simulation, Vec<ActivityDefinition>), anyhow::Error> {
+) -> Result<(Simulation<SimulationClock>, Vec<ActivityDefinition>), anyhow::Error> {
     let cfg: SimulationCfg = SimulationCfg::try_from(cli)?;
     let SimParams {
         nodes,
@@ -267,7 +275,14 @@ pub async fn create_simulation(
         get_validated_activities(&clients, clients_info, sim_params.activity.clone()).await?;
 
     Ok((
-        Simulation::new(cfg, clients, tasks, shutdown_trigger, shutdown_listener),
+        Simulation::new(
+            cfg,
+            clients,
+            tasks,
+            Arc::new(SimulationClock::new(1)?),
+            shutdown_trigger,
+            shutdown_listener,
+        ),
         validated_activities,
     ))
 }

--- a/simln-lib/src/clock.rs
+++ b/simln-lib/src/clock.rs
@@ -1,0 +1,24 @@
+use async_trait::async_trait;
+use std::time::{Duration, SystemTime};
+use tokio::time;
+
+#[async_trait]
+pub trait Clock: Send + Sync {
+    fn now(&self) -> SystemTime;
+    async fn sleep(&self, wait: Duration);
+}
+
+/// Provides a wall clock implementation of the Clock trait.
+#[derive(Clone)]
+pub struct SystemClock {}
+
+#[async_trait]
+impl Clock for SystemClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+
+    async fn sleep(&self, wait: Duration) {
+        time::sleep(wait).await;
+    }
+}

--- a/simln-lib/src/clock.rs
+++ b/simln-lib/src/clock.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
+use std::ops::{Div, Mul};
 use std::time::{Duration, SystemTime};
-use tokio::time;
+use tokio::time::{self, Instant};
+
+use crate::SimulationError;
 
 #[async_trait]
 pub trait Clock: Send + Sync {
@@ -20,5 +23,114 @@ impl Clock for SystemClock {
 
     async fn sleep(&self, wait: Duration) {
         time::sleep(wait).await;
+    }
+}
+
+/// Provides an implementation of the Clock trait that speeds up wall clock time by some factor.
+#[derive(Clone)]
+pub struct SimulationClock {
+    // The multiplier that the regular wall clock is sped up by, must be in [1, 1000].
+    speedup_multiplier: u16,
+
+    /// Tracked so that we can calculate our "fast-forwarded" present relative to the time that we started running at.
+    /// This is useful, because it allows us to still rely on the wall clock, then just convert based on our speedup.
+    /// This field is expressed as an Instant for convenience.
+    start_instant: Instant,
+}
+
+impl SimulationClock {
+    /// Creates a new simulated clock that will speed up wall clock time by the multiplier provided, which must be in
+    /// [1;1000] because our asynchronous sleep only supports a duration of ms granularity.
+    pub fn new(speedup_multiplier: u16) -> Result<Self, SimulationError> {
+        if speedup_multiplier < 1 {
+            return Err(SimulationError::SimulatedNetworkError(
+                "speedup_multiplier must be at least 1".to_string(),
+            ));
+        }
+
+        if speedup_multiplier > 1000 {
+            return Err(SimulationError::SimulatedNetworkError(
+                "speedup_multiplier must be less than 1000, because the simulation sleeps with millisecond
+                    granularity".to_string(),
+            ));
+        }
+
+        Ok(SimulationClock {
+            speedup_multiplier,
+            start_instant: Instant::now(),
+        })
+    }
+
+    /// Calculates the current simulation time based on the current wall clock time.
+    ///
+    /// Separated for testing purposes so that we can fix the current wall clock time and elapsed interval.
+    fn calc_now(&self, now: SystemTime, elapsed: Duration) -> SystemTime {
+        now.checked_add(self.simulated_to_wall_clock(elapsed))
+            .expect("simulation time overflow")
+    }
+
+    /// Converts a duration expressed in wall clock time to the amount of equivalent time that should be used in our
+    /// sped up time.
+    fn wall_clock_to_simulated(&self, d: Duration) -> Duration {
+        d.div(self.speedup_multiplier.into())
+    }
+
+    /// Converts a duration expressed in sped up simulation time to the be expressed in wall clock time.
+    fn simulated_to_wall_clock(&self, d: Duration) -> Duration {
+        d.mul(self.speedup_multiplier.into())
+    }
+}
+
+#[async_trait]
+impl Clock for SimulationClock {
+    /// To get the current time according to our simulation clock, we get the amount of wall clock time that has
+    /// elapsed since the simulator clock was created and multiply it by our speedup.
+    fn now(&self) -> SystemTime {
+        self.calc_now(SystemTime::now(), self.start_instant.elapsed())
+    }
+
+    /// To provide a sped up sleep time, we scale the proposed wait time by our multiplier and sleep.
+    async fn sleep(&self, wait: Duration) {
+        time::sleep(self.wall_clock_to_simulated(wait)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use crate::clock::SimulationClock;
+
+    /// Tests validation and that a multplier of 1 is a regular clock.
+    #[test]
+    fn test_simulation_clock() {
+        assert!(SimulationClock::new(0).is_err());
+        assert!(SimulationClock::new(1001).is_err());
+
+        let clock = SimulationClock::new(1).unwrap();
+        let now = SystemTime::now();
+        let elapsed = Duration::from_secs(15);
+
+        assert_eq!(
+            clock.calc_now(now, elapsed),
+            now.checked_add(elapsed).unwrap(),
+        );
+    }
+
+    /// Test that time is sped up by multiplier.
+    #[test]
+    fn test_clock_speedup() {
+        let clock = SimulationClock::new(10).unwrap();
+        let now = SystemTime::now();
+
+        assert_eq!(
+            clock.calc_now(now, Duration::from_secs(1)),
+            now.checked_add(Duration::from_secs(10)).unwrap(),
+        );
+
+        assert_eq!(
+            clock.calc_now(now, Duration::from_secs(50)),
+            now.checked_add(Duration::from_secs(500)).unwrap(),
+        );
     }
 }

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -29,6 +29,7 @@ use self::defined_activity::DefinedPaymentActivity;
 use self::random_activity::{NetworkGraphView, RandomPaymentActivity};
 
 pub mod cln;
+pub mod clock;
 mod defined_activity;
 pub mod eclair;
 pub mod lnd;

--- a/simln-lib/src/test_utils.rs
+++ b/simln-lib/src/test_utils.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::task::TaskTracker;
 
+use crate::clock::SystemClock;
 use crate::{
     ActivityDefinition, LightningError, LightningNode, NodeInfo, PaymentGenerationError,
     PaymentGenerator, Simulation, SimulationCfg, ValueOrRange,
@@ -195,12 +196,15 @@ impl LightningTestNodeBuilder {
 
 /// Creates a new simulation with the given clients and activity definitions.
 /// Note: This sets a runtime for the simulation of 0, so run() will exit immediately.
-pub fn create_simulation(clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>) -> Simulation {
+pub fn create_simulation(
+    clients: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>,
+) -> Simulation<SystemClock> {
     let (shutdown_trigger, shutdown_listener) = triggered::trigger();
     Simulation::new(
         SimulationCfg::new(Some(0), 0, 0.0, None, None),
         clients,
         TaskTracker::new(),
+        Arc::new(SystemClock {}),
         shutdown_trigger,
         shutdown_listener,
     )


### PR DESCRIPTION
This PR adds a `Clock` trait and makes `Simulation` generic over this trait so that we have the ability to mock time, as described in #81. The default implementation of this trait just thinly wraps a system clock.

For the version where we want to speed things up, we track the instant that we started our clock and apply a multiplier to speed up time passed. For example, if we're running with a multiplier of 10:
* Track our start instant as zero
* One second of "real" time passes, which is equivalent to 10 seconds of simulated time

When dealing with durations, we can simply multiply/divide to move between simulation and real time periods.
When dealing with timestamps, we use the elapsed duration since start to figure out a sped up clock time.

This PR doesn't surface the implementation anywhere, because it doesn't _really_ make sense to run this speed up on real nodes - things get messy when you're using different clocks; if you want things faster on your real node network, just set the activity to fire more often or the random activity to send more payments. 

It is, however, very useful once we've implemented #215, because we can speed up our sim-node network.