### PR TITLE
sim-ln/enhance: Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
To ensure that everyone is working on same `rustc version` and has installed `rustfmt` and `clippy`