### PR TITLE
simln-lib/feature:  Optional name for activity descriptions

### DIFF
--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -8,7 +8,7 @@ use simln_lib::{
     ActivityDefinition, Amount, Interval, LightningError, LightningNode, NodeId, NodeInfo,
     Simulation, SimulationCfg, WriteResults,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::ops::AsyncFn;
 use std::path::PathBuf;
@@ -100,6 +100,9 @@ enum NodeConnection {
 /// [NodeId], which enables the use of public keys and aliases in the simulation description.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ActivityParser {
+    /// Optional name/identifier for this activity
+    #[serde(default)]
+    pub name: Option<String>,
     /// The source of the payment.
     #[serde(with = "serializers::serde_node_id")]
     pub source: NodeId,
@@ -259,9 +262,35 @@ async fn validate_activities(
     get_node_info: impl AsyncFn(&PublicKey) -> Result<NodeInfo, LightningError>,
 ) -> Result<Vec<ActivityDefinition>, LightningError> {
     let mut validated_activities = vec![];
+    let mut activity_names = HashSet::new();
 
     // Make all the activities identifiable by PK internally
-    for act in activity.into_iter() {
+    for (index, act) in activity.into_iter().enumerate() {
+        // Generate a default name if one is not provided
+        let name = match &act.name {
+            Some(name) if !name.is_empty() => {
+                // Optionally check for duplicate names
+                if !activity_names.insert(name.clone()) {
+                    return Err(LightningError::ValidationError(format!(
+                        "duplicate activity name: {}",
+                        name
+                    )));
+                }
+                name.clone()
+            },
+            _ => {
+                let default_name = format!("Activity-{}", index);
+                // Ensure the default name doesn't conflict with an explicit name
+                let mut unique_name = default_name.clone();
+                let mut counter = 1;
+                while !activity_names.insert(unique_name.clone()) {
+                    unique_name = format!("{}-{}", default_name, counter);
+                    counter += 1;
+                }
+                unique_name
+            }
+        };
+
         // We can only map aliases to nodes we control, so if either the source or destination alias
         // is not in alias_node_map, we fail
         let source = if let Some(source) = match &act.source {
@@ -297,6 +326,7 @@ async fn validate_activities(
         };
 
         validated_activities.push(ActivityDefinition {
+            name: Some(name),
             source,
             destination,
             interval_secs: act.interval_secs,

--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -288,7 +288,7 @@ async fn validate_activities(
                     counter += 1;
                 }
                 unique_name
-            }
+            },
         };
 
         // We can only map aliases to nodes we control, so if either the source or destination alias

--- a/simln-lib/src/defined_activity.rs
+++ b/simln-lib/src/defined_activity.rs
@@ -7,6 +7,7 @@ use tokio::time::Duration;
 
 #[derive(Clone)]
 pub struct DefinedPaymentActivity {
+    name: Option<String>,
     destination: NodeInfo,
     start: Option<Duration>,
     count: Option<u64>,
@@ -16,6 +17,7 @@ pub struct DefinedPaymentActivity {
 
 impl DefinedPaymentActivity {
     pub fn new(
+        name: Option<String>,
         destination: NodeInfo,
         start: Option<Duration>,
         count: Option<u64>,
@@ -23,6 +25,7 @@ impl DefinedPaymentActivity {
         amount: ValueOrRange<u64>,
     ) -> Self {
         DefinedPaymentActivity {
+            name,
             destination,
             start,
             count,
@@ -36,8 +39,8 @@ impl fmt::Display for DefinedPaymentActivity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "static payment of {} to {} every {}s",
-            self.amount, self.destination, self.wait
+            "[{:?}] static payment of {} to {} every {}s",
+            self.name, self.amount, self.destination, self.wait
         )
     }
 }

--- a/simln-lib/src/defined_activity.rs
+++ b/simln-lib/src/defined_activity.rs
@@ -39,8 +39,8 @@ impl fmt::Display for DefinedPaymentActivity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[{:?}] static payment of {} to {} every {}s",
-            self.name, self.amount, self.destination, self.wait
+            "static payment of {} to {} every {}s",
+            self.amount, self.destination, self.wait
         )
     }
 }

--- a/simln-lib/src/defined_activity.rs
+++ b/simln-lib/src/defined_activity.rs
@@ -90,6 +90,7 @@ mod tests {
 
     #[test]
     fn test_defined_activity_generator() {
+        let name: String = "test_generator".to_string();
         let node = create_nodes(1, 100000);
         let node = &node.first().unwrap().0;
 
@@ -97,6 +98,7 @@ mod tests {
         let payment_amt = 50;
 
         let generator = DefinedPaymentActivity::new(
+            Option::from(name),
             node.clone(),
             None,
             None,

--- a/simln-lib/src/defined_activity.rs
+++ b/simln-lib/src/defined_activity.rs
@@ -7,6 +7,7 @@ use tokio::time::Duration;
 
 #[derive(Clone)]
 pub struct DefinedPaymentActivity {
+    #[allow(dead_code)]
     name: Option<String>,
     destination: NodeInfo,
     start: Option<Duration>,

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -164,6 +164,8 @@ pub type Interval = ValueOrRange<u16>;
 /// This is constructed during activity validation and passed along to the [Simulation].
 #[derive(Debug, Clone)]
 pub struct ActivityDefinition {
+    /// Optional name/identifier for this activity
+    pub name: Option<String>,
     /// The source of the payment.
     pub source: NodeInfo,
     /// The destination of the payment.

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -964,10 +964,10 @@ impl Simulation {
             let pe_sender = sender.clone();
             tasks.spawn(async move {
                 let source = executor.source_info.clone();
-                let name = executor.name.clone();
+                let name = executor.name.as_deref().unwrap();
 
                 log::info!(
-                    "[{:?}] Starting activity producer for {}: {}.",
+                    "[{}] Starting activity producer for {}: {}.",
                     name,
                     source,
                     executor.payment_generator

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -502,6 +502,7 @@ pub struct WriteResults {
 /// ExecutorKit contains the components required to spin up an activity configured by the user, to be used to
 /// spin up the appropriate producers and consumers for the activity.
 struct ExecutorKit {
+    name: Option<String>,
     source_info: NodeInfo,
     /// We use an arc mutex here because some implementations of the trait will be very expensive to clone.
     /// See [NetworkGraphView] for details.
@@ -808,6 +809,7 @@ impl Simulation {
         if !self.activity.is_empty() {
             for description in self.activity.iter() {
                 let activity_generator = DefinedPaymentActivity::new(
+                    description.name.clone(),
                     description.destination.clone(),
                     description
                         .start_secs
@@ -818,6 +820,7 @@ impl Simulation {
                 );
 
                 generators.push(ExecutorKit {
+                    name: description.name.clone(),
                     source_info: description.source.clone(),
                     // Defined activities have very simple generators, so the traits required are implemented on
                     // a single struct which we just cheaply clone.
@@ -876,6 +879,7 @@ impl Simulation {
 
         for (node_info, capacity) in active_nodes.values() {
             generators.push(ExecutorKit {
+                name: None,
                 source_info: node_info.clone(),
                 network_generator: network_generator.clone(),
                 payment_generator: Box::new(
@@ -960,9 +964,11 @@ impl Simulation {
             let pe_sender = sender.clone();
             tasks.spawn(async move {
                 let source = executor.source_info.clone();
+                let name = executor.name.clone();
 
                 log::info!(
-                    "Starting activity producer for {}: {}.",
+                    "[{:?}] Starting activity producer for {}: {}.",
+                    name,
                     source,
                     executor.payment_generator
                 );

--- a/simln-lib/src/test_utils.rs
+++ b/simln-lib/src/test_utils.rs
@@ -212,6 +212,7 @@ pub fn create_activity(
     amount_msat: u64,
 ) -> ActivityDefinition {
     ActivityDefinition {
+        name: None,
         source,
         destination,
         start_secs: None,


### PR DESCRIPTION
This PR adds an optional `name` field to activity descriptions that is used as a logging prefix. This makes it easier to relate logs to their corresponding activity, improving debugging and monitoring of simulations with multiple activities.

Fixes [#127](https://github.com/bitcoin-dev-project/sim-ln/issues/127)

## Changes
- Added optional `name` field to `ActivityParser` and `ActivityDefinition` structs
- Added optional `name` field to `DefinedPaymentActivity` structs and added allow deadcode due to compiler warnings; this may be an ineffective way.
- Updated `validate_activities()` to handle named activities and auto-generate names for unnamed ones
- Modified `ExecutorKit` to include the activity name
- Modified test utils to pass name check
- Added appropriate documentation

## Implementation Notes
- This feature is currently only available for `DefinedActivity` (not for random activities)
- Names are ensured to be unique across all activities
- Backward compatible with existing simulation configurations

## Test Vector
Tested with the following simulation file:
```json
{
  "nodes": [...],
  "activity": [
    {
      "name": "High-Value-Payments",
      "source": "alice",
      "destination": "erin",
      "interval_secs": 3,
      "amount_msat": 50000
    },
    {
      "source": "dave",
      "destination": "alice",
      "interval_secs": 2,
      "amount_msat": [1000, 3000]
    }
  ]
}
```

Resulting logs properly show activity names:
```
2025-04-13T23:54:09.953Z INFO  [sim_cli::parsing] Connected to erin - Node ID: 020d45c1c54f67ddc1c8e1026fd795111fc6641126f06f5a0e07a730700aeed1bf.
2025-04-13T23:54:09.953Z INFO  [sim_cli::parsing] Connected to alice - Node ID: 027e988bfaf8c5f103f102764c73b4e25d6eda8538a02a8c3363151a748d871243.
2025-04-13T23:54:09.953Z INFO  [sim_cli::parsing] Connected to dave - Node ID: 03cc8e752d37b6b968ed4695b4560bd7804e4f3daa6674e018967a0e481bf0050f.
2025-04-13T23:54:09.953Z INFO  [simln_lib] Running the simulation forever.
2025-04-13T23:54:10.013Z INFO  [simln_lib] Simulation is running on regtest.
2025-04-13T23:54:10.014Z INFO  [simln_lib] Simulating 2 activity on 3 nodes.
2025-04-13T23:54:10.014Z INFO  [simln_lib] Summary of results will be reported every 60s.
2025-04-13T23:54:10.014Z INFO  [simln_lib] [High-Value-Payments] Starting activity producer for alice(027e98...871243): static payment of 50000 to erin(020d45...eed1bf) every 3s.
2025-04-13T23:54:10.014Z INFO  [simln_lib] [Activity-1] Starting activity producer for dave(03cc8e...f0050f): static payment of (1000-3000) to alice(027e98...871243) every 2s.
2025-04-13T23:55:10.015Z INFO  [simln_lib] Processed 48 payments sending 1002670 msat total with 0.00% success rate.
^C2025-04-13T23:55:36.657Z INFO  [sim_cli] Shutting down simulation.
2025-04-13T23:55:36.658Z INFO  [simln_lib] All producers finished. Shutting down.
```