### PR TITLE
Allow unspecified alias destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,11 @@ The example simulation file below sets up the following simulation:
 ```
 
 
-Nodes can be identified by their public key or an id string (as 
-described above). Activity sources and destinations may reference the 
-`id` defined in `nodes`, but destinations that are not listed in `nodes` 
-*must* provide a valid public key.
+Activity sources must reference an `id` defined in `nodes`, because the simulator can
+only send payments from nodes that it controls. Destinations may reference either an
+`id` defined in `nodes` or provide a pubkey or alias of a node in the public network.
+If the alias provided is not unique in the public network, a pubkey must be used
+to identify the node.
 
 ### Simulation Output
 

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -258,6 +258,9 @@ pub enum LightningError {
     /// Error that occurred while listing channels.
     #[error("List channels error: {0}")]
     ListChannelsError(String),
+    /// Error that occurred while getting graph.
+    #[error("Get graph error: {0}")]
+    GetGraphError(String),
 }
 
 /// Information about a Lightning Network node.
@@ -286,6 +289,33 @@ impl Display for NodeInfo {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ChannelInfo {
+    pub channel_id: ShortChannelID,
+    pub capacity_msat: u64,
+}
+
+#[derive(Debug, Clone)]
+/// Graph represents the network graph of the simulated network and is useful for efficient lookups.
+pub struct Graph {
+    // Store nodes' information keyed by their public key.
+    pub nodes_by_pk: HashMap<PublicKey, NodeInfo>,
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        Graph {
+            nodes_by_pk: HashMap::new(),
+        }
+    }
+}
+
+impl Default for Graph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// LightningNode represents the functionality that is required to execute events on a lightning node.
 #[async_trait]
 pub trait LightningNode: Send {
@@ -310,6 +340,8 @@ pub trait LightningNode: Send {
     /// Lists all channels, at present only returns a vector of channel capacities in msat because no further
     /// information is required.
     async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError>;
+    /// Get the network graph from the point of view of a given node.
+    async fn get_graph(&mut self) -> Result<Graph, LightningError>;
 }
 
 /// Represents an error that occurs when generating a destination for a payment.

--- a/simln-lib/src/test_utils.rs
+++ b/simln-lib/src/test_utils.rs
@@ -12,7 +12,7 @@ use tokio_util::task::TaskTracker;
 
 use crate::clock::SystemClock;
 use crate::{
-    ActivityDefinition, LightningError, LightningNode, NodeInfo, PaymentGenerationError,
+    ActivityDefinition, Graph, LightningError, LightningNode, NodeInfo, PaymentGenerationError,
     PaymentGenerator, Simulation, SimulationCfg, ValueOrRange,
 };
 
@@ -89,6 +89,7 @@ mock! {
             ) -> Result<crate::PaymentResult, LightningError>;
         async fn get_node_info(&mut self, node_id: &PublicKey) -> Result<NodeInfo, LightningError>;
         async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError>;
+        async fn get_graph(&mut self) -> Result<Graph, LightningError>;
     }
 }
 


### PR DESCRIPTION
# Description

This PR pulls up the network graph to make it simpler to run node lookups using public keys and aliases. This new node lookup approach is used to allow unspecified aliases in activity destinations by confirming if node(s) with unspecified alias exists in the graph.

# Changes

1. Added Graph struct to simln-lib to enable simpler node lookups.
2. Added `get_graph` function to `LightningNode` trait and implemented it in the different LN implementations.
3. Refactored activities validation to run lookup against Graph directly.
4. Enabled mapping of duplicate aliases in alias_node_map and nodes_by_alias. 

This PR closes #227 