### PR TITLE
docker: fix base image to 1.85

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests${{ inputs.artifact_name }}
+          name: digests-${{ inputs.artifact_name }}-${{ strategy.job-index }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -77,10 +77,15 @@ jobs:
     needs:
       - build
     steps:
-      - name: Download digests
+      - name: Download digest 0
         uses: actions/download-artifact@v4
         with:
-          name: digests${{ inputs.artifact_name }}
+          name: digests-${{ inputs.artifact_name }}-0
+          path: /tmp/digests
+      - name: Download digest 1
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-${{ inputs.artifact_name }}-1
           path: /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 # Run from the root of the project
 
 # Use the rust image as the base image for the build stage
-FROM rust:latest AS base
+FROM rust:1.85.0 AS base
+
 # buildkit will provide this automatically, no need to pass it in
 ARG TARGETARCH
 


### PR DESCRIPTION
Changes to later versions of rust have broken our dockerfile. This change fixes our base image to the version of rust we're currently using, where the break is not present.

We'll need to fix this in future when we bump versions, but for now we make a minimum change to be able to cut the 2.4 release.

Testing this on my personal fork: https://github.com/carlaKC/sim-ln/actions/runs/14882930754
Which will push to my dockerhub account: https://hub.docker.com/r/carlakirkcohen/simln/tags