### PR TITLE
sim-lib: exclude nodes from random activity

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -56,8 +56,7 @@ async fn main() -> anyhow::Result<()> {
         log::info!("Shutting down simulation.");
         sim2.shutdown();
     })?;
-
-    sim.run(&validated_activities).await?;
+    sim.run(validated_activities).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/sim-ln/issues/269

Added an `ActivityOpts` enum to pass `DefinedActivity` or `Random` and optionally specify nodes to be excluded in the random variant. 

