### PR TITLE
pass cfg to `create_simulation_with_network` 

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -6,6 +6,7 @@ use sim_cli::parsing::{create_simulation, create_simulation_with_network, parse_
 use simln_lib::{
     latency_interceptor::LatencyIntercepor,
     sim_node::{CustomRecords, Interceptor},
+    SimulationCfg,
 };
 use simple_logger::SimpleLogger;
 use tokio_util::task::TaskTracker;
@@ -41,9 +42,11 @@ async fn main() -> anyhow::Result<()> {
         } else {
             vec![]
         };
+        let sim_cfg: SimulationCfg = SimulationCfg::try_from(&cli)?;
         create_simulation_with_network(
-            &cli,
+            sim_cfg,
             &sim_params,
+            cli.speedup_clock.unwrap_or(1),
             tasks.clone(),
             interceptors,
             CustomRecords::default(),

--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -145,7 +145,7 @@ impl Cli {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SimParams {
     #[serde(default)]
-    nodes: Vec<NodeConnection>,
+    pub nodes: Vec<NodeConnection>,
     #[serde(default)]
     pub sim_network: Vec<NetworkParser>,
     #[serde(default)]
@@ -242,13 +242,13 @@ struct NodeMapping {
 }
 
 pub async fn create_simulation_with_network(
-    cli: &Cli,
+    cfg: SimulationCfg,
     sim_params: &SimParams,
+    clock_speedup: u16,
     tasks: TaskTracker,
     interceptors: Vec<Arc<dyn Interceptor>>,
     custom_records: CustomRecords,
 ) -> Result<(Simulation<SimulationClock>, Vec<ActivityDefinition>), anyhow::Error> {
-    let cfg: SimulationCfg = SimulationCfg::try_from(cli)?;
     let SimParams {
         nodes: _,
         sim_network,
@@ -284,7 +284,7 @@ pub async fn create_simulation_with_network(
         .map_err(|e| SimulationError::SimulatedNetworkError(format!("{:?}", e)))?,
     ));
 
-    let clock = Arc::new(SimulationClock::new(cli.speedup_clock.unwrap_or(1))?);
+    let clock = Arc::new(SimulationClock::new(clock_speedup)?);
 
     // Copy all simulated channels into a read-only routing graph, allowing to pathfind for
     // individual payments without locking th simulation graph (this is a duplication of the channels,

--- a/simln-lib/src/clock.rs
+++ b/simln-lib/src/clock.rs
@@ -61,6 +61,16 @@ impl SimulationClock {
         })
     }
 
+    /// Returns the instant that the simulation clock was started at.
+    pub fn get_start_instant(&self) -> Instant {
+        self.start_instant
+    }
+
+    /// Returns the speedup multiplier applied to time.
+    pub fn get_speedup_multiplier(&self) -> u16 {
+        self.speedup_multiplier
+    }
+
     /// Calculates the current simulation time based on the current wall clock time.
     ///
     /// Separated for testing purposes so that we can fix the current wall clock time and elapsed interval.


### PR DESCRIPTION
I think it'd be easier to use `create_simulation_with_network` outside of `sim-cli` if it took a `SimulationCfg` instead of the `cli`. 