### PR TITLE
Fix: Remove Unnecessary &mut self Requirements from LightningNode Trait

### DIFF
--- a/simln-lib/src/cln.rs
+++ b/simln-lib/src/cln.rs
@@ -112,7 +112,7 @@ impl ClnNode {
     /// Fetch channels belonging to the local node, initiated locally if is_source is true, and initiated remotely if
     /// is_source is false. Introduced as a helper function because CLN doesn't have a single API to list all of our
     /// node's channels.
-    async fn node_channels(&mut self, is_source: bool) -> Result<Vec<u64>, LightningError> {
+    async fn node_channels(&self, is_source: bool) -> Result<Vec<u64>, LightningError> {
         let req = if is_source {
             ListchannelsRequest {
                 source: Some(self.info.pubkey.serialize().to_vec()),
@@ -265,7 +265,7 @@ impl LightningNode for ClnNode {
         }
     }
 
-    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError> {
+    async fn list_channels(&self) -> Result<Vec<u64>, LightningError> {
         let mut node_channels = self.node_channels(true).await?;
         node_channels.extend(self.node_channels(false).await?);
         Ok(node_channels)

--- a/simln-lib/src/eclair.rs
+++ b/simln-lib/src/eclair.rs
@@ -222,7 +222,7 @@ impl LightningNode for EclairNode {
         })
     }
 
-    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError> {
+    async fn list_channels(&self) -> Result<Vec<u64>, LightningError> {
         let client = self.client.lock().await;
         let channels: ChannelsResponse = client
             .request("channels", None)

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -341,7 +341,7 @@ pub trait LightningNode: Send {
     async fn get_node_info(&self, node_id: &PublicKey) -> Result<NodeInfo, LightningError>;
     /// Lists all channels, at present only returns a vector of channel capacities in msat because no further
     /// information is required.
-    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError>;
+    async fn list_channels(&self) -> Result<Vec<u64>, LightningError>;
     /// Get the network graph from the point of view of a given node.
     async fn get_graph(&self) -> Result<Graph, LightningError>;
 }

--- a/simln-lib/src/lnd.rs
+++ b/simln-lib/src/lnd.rs
@@ -260,7 +260,7 @@ impl LightningNode for LndNode {
         }
     }
 
-    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError> {
+    async fn list_channels(&self) -> Result<Vec<u64>, LightningError> {
         let mut client = self.client.lock().await;
         let channels = client
             .lightning()

--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -709,7 +709,7 @@ impl<T: SimNetwork> LightningNode for SimNode<'_, T> {
         Ok(self.network.lock().await.lookup_node(node_id)?.0)
     }
 
-    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError> {
+    async fn list_channels(&self) -> Result<Vec<u64>, LightningError> {
         Ok(self.network.lock().await.lookup_node(&self.info.pubkey)?.1)
     }
 
@@ -1897,7 +1897,7 @@ mod tests {
 
         // Create a simulated node for the first channel in our network.
         let pk = channels[0].node_1.policy.pubkey;
-        let mut node = SimNode::new(
+        let node = SimNode::new(
             node_info(pk, String::default()),
             sim_network.clone(),
             Arc::new(graph),

--- a/simln-lib/src/test_utils.rs
+++ b/simln-lib/src/test_utils.rs
@@ -88,7 +88,7 @@ mock! {
                 shutdown: triggered::Listener,
             ) -> Result<crate::PaymentResult, LightningError>;
         async fn get_node_info(&self, node_id: &PublicKey) -> Result<NodeInfo, LightningError>;
-        async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError>;
+        async fn list_channels(&self) -> Result<Vec<u64>, LightningError>;
         async fn get_graph(&self) -> Result<Graph, LightningError>;
     }
 }


### PR DESCRIPTION
closes #264 
This PR refactors the LightningNode trait and its implementations to remove unnecessary &mut self references for methods that do not mutate internal state.

### Motivation
Previously, several trait methods like get_network and list_channels required &mut self, even though they only retrieved information. This requirement leaked internal implementation details—specifically, that the underlying client field required a mutable reference to make gRPC or HTTP calls.

This design was misleading and unnecessarily restricted usage of the trait, e.g. preventing multiple read-only operations from being performed concurrently on the same node.

### Changes
Wrapped client fields (e.g. NodeClient, EclairClient, etc.) inside tokio::sync::Mutex.

Updated all client usages to acquire a mutable lock via let mut client = self.client.lock().await;.

Updated trait method signatures to require &self instead of &mut self where applicable.

Ensured thread-safe, concurrent-friendly behavior without sacrificing correctness or clarity.