### PR TITLE
Simln-lib: log the specific error message that CLN encounters during startup

### DIFF
--- a/simln-lib/src/cln.rs
+++ b/simln-lib/src/cln.rs
@@ -47,16 +47,19 @@ impl ClnNode {
         let tls = ClientTlsConfig::new()
             .domain_name("cln")
             .identity(Identity::from_pem(
-                reader(&connection.client_cert).await.map_err(|_| {
-                    LightningError::ConnectionError("Cannot loads client certificate".to_string())
+                reader(&connection.client_cert).await.map_err(|err| {
+                    LightningError::ConnectionError(format!(
+                        "Cannot loads client certificate: {}",
+                        err
+                    ))
                 })?,
-                reader(&connection.client_key).await.map_err(|_| {
-                    LightningError::ConnectionError("Cannot loads client key".to_string())
+                reader(&connection.client_key).await.map_err(|err| {
+                    LightningError::ConnectionError(format!("Cannot loads client key: {}", err))
                 })?,
             ))
             .ca_certificate(Certificate::from_pem(
-                reader(&connection.ca_cert).await.map_err(|_| {
-                    LightningError::ConnectionError("Cannot loads CA certificate".to_string())
+                reader(&connection.ca_cert).await.map_err(|err| {
+                    LightningError::ConnectionError(format!("Cannot loads CA certificate: {}", err))
                 })?,
             ));
 
@@ -64,13 +67,19 @@ impl ClnNode {
             Channel::from_shared(connection.address)
                 .map_err(|err| LightningError::ConnectionError(err.to_string()))?
                 .tls_config(tls)
-                .map_err(|_| {
-                    LightningError::ConnectionError("Cannot establish tls connection".to_string())
+                .map_err(|err| {
+                    LightningError::ConnectionError(format!(
+                        "Cannot establish tls connection: {}",
+                        err
+                    ))
                 })?
                 .connect()
                 .await
-                .map_err(|_| {
-                    LightningError::ConnectionError("Cannot connect to gRPC server".to_string())
+                .map_err(|err| {
+                    LightningError::ConnectionError(format!(
+                        "Cannot connect to gRPC server: {}",
+                        err
+                    ))
                 })?,
         );
 

--- a/simln-lib/src/cln.rs
+++ b/simln-lib/src/cln.rs
@@ -49,17 +49,17 @@ impl ClnNode {
             .identity(Identity::from_pem(
                 reader(&connection.client_cert).await.map_err(|err| {
                     LightningError::ConnectionError(format!(
-                        "Cannot loads client certificate: {}",
+                        "Cannot load client certificate: {}",
                         err
                     ))
                 })?,
                 reader(&connection.client_key).await.map_err(|err| {
-                    LightningError::ConnectionError(format!("Cannot loads client key: {}", err))
+                    LightningError::ConnectionError(format!("Cannot load client key: {}", err))
                 })?,
             ))
             .ca_certificate(Certificate::from_pem(
                 reader(&connection.ca_cert).await.map_err(|err| {
-                    LightningError::ConnectionError(format!("Cannot loads CA certificate: {}", err))
+                    LightningError::ConnectionError(format!("Cannot load CA certificate: {}", err))
                 })?,
             ));
 


### PR DESCRIPTION
Closes #286 

This PR adds error messages from the CLN node during startup to help with debugging. Currently, we only log a custom message and ignore app errors.