### PR TITLE
Report Pathfinding Outcomes to Scorer in SimNode

### DIFF
--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -262,7 +262,7 @@ pub async fn create_simulation_with_network(
     (
         Simulation<SimulationClock>,
         Vec<ActivityDefinition>,
-        HashMap<PublicKey, Arc<Mutex<SimNode<SimGraph>>>>,
+        HashMap<PublicKey, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
     ),
     anyhow::Error,
 > {
@@ -313,7 +313,7 @@ pub async fn create_simulation_with_network(
     // custom actions on the simulated network. For the nodes we'll pass our simulation, cast them
     // to a dyn trait and exclude any nodes that shouldn't be included in random activity
     // generation.
-    let nodes = ln_node_from_graph(simulation_graph.clone(), routing_graph).await;
+    let nodes = ln_node_from_graph(simulation_graph.clone(), routing_graph, clock.clone()).await?;
     let mut nodes_dyn: HashMap<_, Arc<Mutex<dyn LightningNode>>> = nodes
         .iter()
         .map(|(pk, node)| (*pk, Arc::clone(node) as Arc<Mutex<dyn LightningNode>>))

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -433,7 +433,7 @@ impl Display for PaymentResult {
 }
 
 /// Represents all possible outcomes of a Lightning Network payment attempt.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PaymentOutcome {
     /// Payment completed successfully, reaching its intended recipient.
     Success,

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -263,6 +263,9 @@ pub enum LightningError {
     /// Error that occurred while getting graph.
     #[error("Get graph error: {0}")]
     GetGraphError(String),
+    /// Error that occured when getting clock info.
+    #[error("SystemTime conversion error: {0}")]
+    SystemTimeConversionError(#[from] SystemTimeError),
 }
 
 /// Information about a Lightning Network node.

--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -456,6 +456,8 @@ pub enum PaymentOutcome {
     NotDispatched,
     /// The payment was dispatched but its final status could not be determined.
     TrackPaymentFailed,
+    /// The payment failed at the provided index in the path.
+    IndexFailure(usize),
 }
 
 /// Describes a payment from a source node to a destination node.

--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -1475,7 +1475,7 @@ async fn propagate_payment(request: PropagatePaymentRequest) {
             );
             PaymentResult {
                 htlc_count: 0,
-                payment_outcome: PaymentOutcome::Unknown,
+                payment_outcome: PaymentOutcome::IndexFailure(fail_idx.unwrap_or(0)),
             }
         },
         Err(critical_err) => {
@@ -2544,7 +2544,7 @@ mod tests {
 
         assert!(matches!(
             result.unwrap().payment_outcome,
-            PaymentOutcome::Unknown
+            PaymentOutcome::IndexFailure(0)
         ));
 
         // The interceptor returned a forwarding error, check that a simulation shutdown has not


### PR DESCRIPTION

### Description

This PR reports pathfinding outcomes to scorer in SimNode. This significantly improves the realism of pathfinding simulations by allowing the scorer to update based on actual payment success or failure.

This is an attempt to complete the work started on this [branch](https://github.com/carlaKC/sim-ln/tree/279-report-payments).

### Changes

- Payment path now tracked in `SimNode.in_flight` using `InFlightPayment`.
- Added `IndexFailure` `PaymentOutcome` variant, which specifically captures the index of the channel in the payment path that caused the failure.
- Now tracking simulation time in `SimNode` using `SimulationClock` for accurate duration reporting.
- Now reporting payment success/failure to `SimNode.scorer` using the newly tracked path and failure index (if applicable).

This PR closes #279
