### PR TITLE
sim-cli/refactor: pass clock into create_simulation_with_network

### DIFF
--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use log::LevelFilter;
 use sim_cli::parsing::{create_simulation, create_simulation_with_network, parse_sim_params, Cli};
 use simln_lib::{
+    clock::SimulationClock,
     latency_interceptor::LatencyIntercepor,
     sim_node::{CustomRecords, Interceptor},
     SimulationCfg,
@@ -43,10 +44,11 @@ async fn main() -> anyhow::Result<()> {
             vec![]
         };
         let sim_cfg: SimulationCfg = SimulationCfg::try_from(&cli)?;
+        let clock = Arc::new(SimulationClock::new(cli.speedup_clock.unwrap_or(1))?);
         let (sim, validated_activities, _) = create_simulation_with_network(
             sim_cfg,
             &sim_params,
-            cli.speedup_clock.unwrap_or(1),
+            clock,
             tasks.clone(),
             interceptors,
             CustomRecords::default(),

--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -244,7 +244,7 @@ struct NodeMapping {
 pub async fn create_simulation_with_network(
     cfg: SimulationCfg,
     sim_params: &SimParams,
-    clock_speedup: u16,
+    clock: Arc<SimulationClock>,
     tasks: TaskTracker,
     interceptors: Vec<Arc<dyn Interceptor>>,
     custom_records: CustomRecords,
@@ -290,8 +290,6 @@ pub async fn create_simulation_with_network(
         )
         .map_err(|e| SimulationError::SimulatedNetworkError(format!("{:?}", e)))?,
     ));
-
-    let clock = Arc::new(SimulationClock::new(clock_speedup)?);
 
     // Copy all simulated channels into a read-only routing graph, allowing to pathfind for
     // individual payments without locking th simulation graph (this is a duplication of the channels,


### PR DESCRIPTION
If using SimLN as a library, you may want to use the sped up simulation clock in other places. Pass the clock into create_simulation_with_network so that it can be created (and used) externally, and the helper function just sets up the simulation using the clock it is provided.

An alternative approach to this would be to make the Simulation::clock pub, but the downside of this is that you can hit circular dependencies
- for example, if you want to use the clock in an interceptor: you need the clock to create the interceptor, but you need to interceptor to create the simulation and thus the clock.