### PR TITLE
Fix Critical Error handling in HTLC interception

### DIFF
--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -845,7 +845,8 @@ pub struct HtlcRef {
 /// If any interceptor returns a `ForwardingError`, it triggers a shutdown signal to all other
 /// interceptors and waits for them to shutdown. The forwarding error is then returned.
 /// If any interceptor returns a `CriticalError`, it is immediately returned to trigger a
-/// simulation shutdown. TODO: If a critical error happens, we could instead trigger the shutdown
+/// simulation shutdown.
+// If a critical error happens, we could instead trigger the shutdown
 /// for the interceptors and let them finish before returning.
 /// While waiting on the interceptors, it listens on the shutdown_listener for any signals from
 /// upstream and trigger shutdowns to the interceptors if needed.


### PR DESCRIPTION
closes #272 

TODO: This needed to be done.

Currently, when a CriticalError occurs during HTLC interception in [handle_intercepted_htlc](https://github.com/bitcoin-dev-project/sim-ln/blob/c4059cd30353b03c0d7c495121ef7ce9e698af47/simln-lib/src/sim_node.rs#L854), the function immediately returns without waiting for other running interceptors to complete. This can leave interceptors in an inconsistent state and prevent proper cleanup.

## Changes
- Store critical errors instead of immediately returning, When a CriticalError occurs, store it in a local variable rather than returning immediately.
- Send shutdown signal to all other running interceptors when a critical error is encountered
- Added critical_error variable to store any CriticalError that occurs
- Modified the Err(e) match arm to store the error and trigger shutdown instead of immediate return
