### PR TITLE
readme: fix config doc for eclair

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ have permission to execute commands on. Note that the current version
 of the simulator uses keysend to execute payments, which must be enabled as follows:
 * LND: `--accept-keysend`
 * CLN: enabled by default
-* Eclair: `--features.keysend=optional`
+* Eclair: `-Declair.features.keysend=optional` (or `--features.keysend=optional` if you're using Polar)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ of the simulator uses keysend to execute payments, which must be enabled as foll
 * CLN: enabled by default
 * Eclair: `-Declair.features.keysend=optional` (or `--features.keysend=optional` if you're using Polar)
 
+NOTE: for CLN `keysend` to work with eclair, you need to add additional config to eclair:
+```
+-Declair.channel.min-final-expiry-delta-blocks=N
+-Declair.channel.fulfill-safety-before-timeout-blocks=M
+```
+where N and M are numbers, and N must be larger than M (N must be 22, CLN's default, or more)
+
 ## Getting Started
 
 Once you have all the pre-requisites installed, clone the repo:


### PR DESCRIPTION
In this PR, we update the eclair config to enable keysend. Initially, we are using a config that is only applicable for running Eclair in Polar. `--features.keysend=optional` works only in polar [SEE](https://github.com/jamaljsr/polar/blob/master/docker/eclair/docker-entrypoint.sh#L32-L34).

We also add additional configuration to enable CLN to send keysend payments to Eclair. Without 
```
-Declair.channel.min-final-expiry-delta-blocks
```
 the payment will fail because [CLN uses 22](https://github.com/ElementsProject/lightning/blob/master/plugins/keysend.c#L237) for keysend while Eclair's minimum [default is 30](https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf#L148-L149). 
```
-Declair.channel.fulfill-safety-before-timeout-blocks
```
is explicitly required when `-Declair.channel.min-final-expiry-delta-blocks` is set and must be less than it. [SEE](https://github.com/ACINQ/eclair/pull/2574#issuecomment-1398141344)

