### PR TITLE
Decrease Variance of LogNormal to Converge on Expected Value Sooner

### DIFF
--- a/simln-lib/src/lib.rs
+++ b/simln-lib/src/lib.rs
@@ -2119,7 +2119,8 @@ mod tests {
             elapsed
         );
         let expected_payment_list = vec![
-            pk1, pk2, pk1, pk1, pk1, pk3, pk3, pk3, pk4, pk3, pk2, pk1, pk4,
+            pk2, pk1, pk1, pk3, pk2, pk4, pk3, pk2, pk2, pk4, pk3, pk2, pk3, pk2, pk1, pk4, pk2,
+            pk2, pk2, pk2, pk1, pk1, pk4, pk2,
         ];
 
         assert!(


### PR DESCRIPTION
See rationale [here](https://github.com/bitcoin-dev-project/sim-ln/issues/111#issuecomment-3185472086).

This PR makes a fix to the way we pick our `LogNormal` distribution's parameters which results in our getting to an average of our `expected_payment_amount` much sooner.

As this changes the way we pick payments, the hard-coded ordering of some of our tests has to change.
While I'm here, I also make some changes to long-running unit tests to speed them up a bit. 