### PR TITLE
Add Custom Pathfinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "dialoguer",
  "futures",
  "hex",
+ "lightning",
  "log",
  "openssl",
  "rand",

--- a/sim-cli/Cargo.toml
+++ b/sim-cli/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.30"
 console-subscriber = { version = "0.4.0", optional = true}
 tokio-util = { version = "0.7.13", features = ["rt"] }
 openssl = { version = "0.10", features = ["vendored"] }
+lightning = { version = "0.0.123" }
 
 [features]
 dev = ["console-subscriber"]

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     cli.validate(&sim_params)?;
 
     let tasks = TaskTracker::new();
-    
+
     // Create the pathfinder instance
     let pathfinder = DefaultPathFinder;
 
@@ -57,8 +57,8 @@ async fn main() -> anyhow::Result<()> {
             clock,
             tasks.clone(),
             interceptors,
-            pathfinder,
             CustomRecords::default(),
+            pathfinder,
         )
         .await?;
         (sim, validated_activities)
@@ -73,4 +73,4 @@ async fn main() -> anyhow::Result<()> {
     sim.run(&validated_activities).await?;
 
     Ok(())
-} 
+}

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -12,6 +12,9 @@ use simln_lib::{
 use simple_logger::SimpleLogger;
 use tokio_util::task::TaskTracker;
 
+// Import the pathfinder types
+use simln_lib::sim_node::DefaultPathFinder;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Enable tracing if building in developer mode.
@@ -33,6 +36,9 @@ async fn main() -> anyhow::Result<()> {
     cli.validate(&sim_params)?;
 
     let tasks = TaskTracker::new();
+    
+    // Create the pathfinder instance
+    let pathfinder = DefaultPathFinder;
 
     let (sim, validated_activities) = if sim_params.sim_network.is_empty() {
         create_simulation(&cli, &sim_params, tasks.clone()).await?
@@ -51,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
             clock,
             tasks.clone(),
             interceptors,
+            pathfinder,
             CustomRecords::default(),
         )
         .await?;
@@ -66,4 +73,4 @@ async fn main() -> anyhow::Result<()> {
     sim.run(&validated_activities).await?;
 
     Ok(())
-}
+} 

--- a/sim-cli/src/main.rs
+++ b/sim-cli/src/main.rs
@@ -12,9 +12,6 @@ use simln_lib::{
 use simple_logger::SimpleLogger;
 use tokio_util::task::TaskTracker;
 
-// Import the pathfinder types
-use simln_lib::sim_node::DefaultPathFinder;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Enable tracing if building in developer mode.
@@ -37,9 +34,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tasks = TaskTracker::new();
 
-    // Create the pathfinder instance
-    let pathfinder = DefaultPathFinder;
-
     let (sim, validated_activities) = if sim_params.sim_network.is_empty() {
         create_simulation(&cli, &sim_params, tasks.clone()).await?
     } else {
@@ -58,7 +52,6 @@ async fn main() -> anyhow::Result<()> {
             tasks.clone(),
             interceptors,
             CustomRecords::default(),
-            pathfinder,
         )
         .await?;
         (sim, validated_activities)

--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 use simln_lib::clock::SimulationClock;
 use simln_lib::sim_node::{
     ln_node_from_graph, populate_network_graph, ChannelPolicy, CustomRecords, Interceptor,
-    SimGraph, SimNode, SimulatedChannel,
+    PathFinder, SimGraph, SimulatedChannel,
 };
+
 use simln_lib::{
     cln, cln::ClnNode, eclair, eclair::EclairNode, lnd, lnd::LndNode, serializers,
     ActivityDefinition, Amount, Interval, LightningError, LightningNode, NodeId, NodeInfo,
@@ -258,6 +259,7 @@ pub async fn create_simulation_with_network(
     tasks: TaskTracker,
     interceptors: Vec<Arc<dyn Interceptor>>,
     custom_records: CustomRecords,
+    pathfinder: P,
 ) -> Result<
     (
         Simulation<SimulationClock>,
@@ -308,12 +310,11 @@ pub async fn create_simulation_with_network(
         populate_network_graph(channels, clock.clone())
             .map_err(|e| SimulationError::SimulatedNetworkError(format!("{:?}", e)))?,
     );
-
     // We want the full set of nodes in our graph to return to the caller so that they can take
     // custom actions on the simulated network. For the nodes we'll pass our simulation, cast them
     // to a dyn trait and exclude any nodes that shouldn't be included in random activity
     // generation.
-    let nodes = ln_node_from_graph(simulation_graph.clone(), routing_graph, clock.clone()).await?;
+    let nodes = ln_node_from_graph(simulation_graph.clone(), routing_graph, clock.clone(), pathfinder).await?;
     let mut nodes_dyn: HashMap<_, Arc<Mutex<dyn LightningNode>>> = nodes
         .iter()
         .map(|(pk, node)| (*pk, Arc::clone(node) as Arc<Mutex<dyn LightningNode>>))
@@ -321,7 +322,6 @@ pub async fn create_simulation_with_network(
     for pk in exclude {
         nodes_dyn.remove(pk);
     }
-
     let validated_activities =
         get_validated_activities(&nodes_dyn, nodes_info, sim_params.activity.clone()).await?;
 
@@ -338,6 +338,7 @@ pub async fn create_simulation_with_network(
         nodes,
     ))
 }
+
 
 /// Parses the cli options provided and creates a simulation to be run, connecting to lightning nodes and validating
 /// any activity described in the simulation file.

--- a/sim-cli/src/parsing.rs
+++ b/sim-cli/src/parsing.rs
@@ -5,8 +5,8 @@ use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use simln_lib::clock::SimulationClock;
 use simln_lib::sim_node::{
-    ln_node_from_graph, populate_network_graph, ChannelPolicy, CustomRecords, Interceptor,
-    PathFinder, SimGraph, SimulatedChannel,
+    ln_node_from_graph, populate_network_graph, ChannelPolicy, CustomRecords, DefaultPathFinder,
+    Interceptor, SimGraph, SimulatedChannel,
 };
 
 use simln_lib::{
@@ -259,12 +259,11 @@ pub async fn create_simulation_with_network(
     tasks: TaskTracker,
     interceptors: Vec<Arc<dyn Interceptor>>,
     custom_records: CustomRecords,
-    pathfinder: P,
 ) -> Result<
     (
         Simulation<SimulationClock>,
         Vec<ActivityDefinition>,
-        HashMap<PublicKey, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
+        HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>>,
     ),
     anyhow::Error,
 > {
@@ -310,11 +309,21 @@ pub async fn create_simulation_with_network(
         populate_network_graph(channels, clock.clone())
             .map_err(|e| SimulationError::SimulatedNetworkError(format!("{:?}", e)))?,
     );
+
+    // Create the pathfinder instance
+    let pathfinder = DefaultPathFinder::new(routing_graph.clone());
+
     // We want the full set of nodes in our graph to return to the caller so that they can take
     // custom actions on the simulated network. For the nodes we'll pass our simulation, cast them
     // to a dyn trait and exclude any nodes that shouldn't be included in random activity
     // generation.
-    let nodes = ln_node_from_graph(simulation_graph.clone(), routing_graph, clock.clone(), pathfinder).await?;
+    let nodes = ln_node_from_graph(
+        simulation_graph.clone(),
+        routing_graph,
+        clock.clone(),
+        pathfinder,
+    )
+    .await?;
     let mut nodes_dyn: HashMap<_, Arc<Mutex<dyn LightningNode>>> = nodes
         .iter()
         .map(|(pk, node)| (*pk, Arc::clone(node) as Arc<Mutex<dyn LightningNode>>))
@@ -635,233 +644,4 @@ pub async fn get_validated_activities(
     };
 
     validate_activities(activity.to_vec(), activity_validation_params).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-    use lightning::routing::gossip::NetworkGraph;
-    use lightning::routing::router::{find_route, PaymentParameters, Route, RouteParameters};
-    use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringDecayParameters};
-    use rand::RngCore;
-    use simln_lib::clock::SystemClock;
-    use simln_lib::sim_node::{
-        ln_node_from_graph, populate_network_graph, PathFinder, SimGraph, WrappedLog,
-    };
-    use simln_lib::SimulationError;
-    use std::sync::Arc;
-    use tokio::sync::Mutex;
-    use tokio_util::task::TaskTracker;
-
-    /// Gets a key pair generated in a pseudorandom way.
-    fn get_random_keypair() -> (SecretKey, PublicKey) {
-        let secp = Secp256k1::new();
-        let mut rng = rand::thread_rng();
-        let mut bytes = [0u8; 32];
-        rng.fill_bytes(&mut bytes);
-        let secret_key = SecretKey::from_slice(&bytes).expect("Failed to create secret key");
-        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
-        (secret_key, public_key)
-    }
-
-    /// Helper function to create simulated channels for testing
-    fn create_simulated_channels(num_channels: usize, capacity_msat: u64) -> Vec<SimulatedChannel> {
-        let mut channels = Vec::new();
-        for i in 0..num_channels {
-            let (_node1_sk, node1_pubkey) = get_random_keypair();
-            let (_node2_sk, node2_pubkey) = get_random_keypair();
-
-            let channel = SimulatedChannel::new(
-                capacity_msat,
-                ShortChannelID::from(i as u64),
-                ChannelPolicy {
-                    pubkey: node1_pubkey,
-                    alias: "".to_string(),
-                    max_htlc_count: 483,
-                    max_in_flight_msat: capacity_msat / 2,
-                    min_htlc_size_msat: 1000,
-                    max_htlc_size_msat: capacity_msat / 2,
-                    cltv_expiry_delta: 144,
-                    base_fee: 1000,
-                    fee_rate_prop: 100,
-                },
-                ChannelPolicy {
-                    pubkey: node2_pubkey,
-                    alias: "".to_string(),
-                    max_htlc_count: 483,
-                    max_in_flight_msat: capacity_msat / 2,
-                    min_htlc_size_msat: 1000,
-                    max_htlc_size_msat: capacity_msat / 2,
-                    cltv_expiry_delta: 144,
-                    base_fee: 1000,
-                    fee_rate_prop: 100,
-                },
-            );
-            channels.push(channel);
-        }
-        channels
-    }
-
-    /// A pathfinder that always fails to find a path
-    #[derive(Clone)]
-    pub struct AlwaysFailPathFinder;
-
-    impl<'a> PathFinder<'a> for AlwaysFailPathFinder {
-        fn find_route(
-            &self,
-            _source: &PublicKey,
-            _dest: PublicKey,
-            _amount_msat: u64,
-            _pathfinding_graph: &NetworkGraph<&'a WrappedLog>,
-            _scorer: &ProbabilisticScorer<Arc<NetworkGraph<&'a WrappedLog>>, &'a WrappedLog>,
-        ) -> Result<Route, SimulationError> {
-            Err(SimulationError::SimulatedNetworkError(
-                "No route found".to_string(),
-            ))
-        }
-    }
-
-    /// A pathfinder that only returns single-hop paths
-    #[derive(Clone)]
-    pub struct SingleHopOnlyPathFinder;
-
-    impl<'a> PathFinder<'a> for SingleHopOnlyPathFinder {
-        fn find_route(
-            &self,
-            source: &PublicKey,
-            dest: PublicKey,
-            amount_msat: u64,
-            pathfinding_graph: &NetworkGraph<&'a WrappedLog>,
-            scorer: &ProbabilisticScorer<Arc<NetworkGraph<&'a WrappedLog>>, &'a WrappedLog>,
-        ) -> Result<Route, SimulationError> {
-            // Try to find a direct route only (single hop)
-            let route_params = RouteParameters {
-                payment_params: PaymentParameters::from_node_id(dest, 0)
-                    .with_max_total_cltv_expiry_delta(u32::MAX)
-                    .with_max_path_count(1)
-                    .with_max_channel_saturation_power_of_half(1),
-                final_value_msat: amount_msat,
-                max_total_routing_fee_msat: None,
-            };
-
-            // Try to find a route - if it fails or has more than one hop, return an error
-            match find_route(
-                source,
-                &route_params,
-                pathfinding_graph,
-                None,
-                &WrappedLog {},
-                scorer,
-                &Default::default(),
-                &[0; 32],
-            ) {
-                Ok(route) => {
-                    // Check if the route has exactly one hop
-                    if route.paths.len() == 1 && route.paths[0].hops.len() == 1 {
-                        Ok(route)
-                    } else {
-                        Err(SimulationError::SimulatedNetworkError(
-                            "No direct route found".to_string(),
-                        ))
-                    }
-                },
-                Err(e) => Err(SimulationError::SimulatedNetworkError(e.err)),
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_always_fail_pathfinder() {
-        let channels = create_simulated_channels(3, 1_000_000_000);
-        let routing_graph =
-            Arc::new(populate_network_graph(channels.clone(), Arc::new(SystemClock {})).unwrap());
-
-        let pathfinder = AlwaysFailPathFinder;
-        let source = channels[0].get_node_1_pubkey();
-        let dest = channels[2].get_node_2_pubkey();
-
-        let scorer = ProbabilisticScorer::new(
-            ProbabilisticScoringDecayParameters::default(),
-            routing_graph.clone(),
-            &WrappedLog {},
-        );
-
-        let result = pathfinder.find_route(&source, dest, 100_000, &routing_graph,);
-
-        // Should always fail
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_single_hop_only_pathfinder() {
-        let channels = create_simulated_channels(3, 1_000_000_000);
-        let routing_graph =
-            Arc::new(populate_network_graph(channels.clone(), Arc::new(SystemClock {})).unwrap());
-
-        let pathfinder = SingleHopOnlyPathFinder;
-        let source = channels[0].get_node_1_pubkey();
-
-        let scorer = ProbabilisticScorer::new(
-            ProbabilisticScoringDecayParameters::default(),
-            routing_graph.clone(),
-            &WrappedLog {},
-        );
-
-        // Test direct connection (should work)
-        let direct_dest = channels[0].get_node_2_pubkey();
-        let result = pathfinder.find_route(&source, direct_dest, 100_000, &routing_graph,);
-
-        if result.is_ok() {
-            let route = result.unwrap();
-            assert_eq!(route.paths[0].hops.len(), 1); // Only one hop
-        }
-
-        // Test indirect connection (should fail)
-        let indirect_dest = channels[2].get_node_2_pubkey();
-        let _result =
-            pathfinder.find_route(&source, indirect_dest, 100_000, &routing_graph,);
-
-        // May fail because no direct route exists
-        // (depends on your test network topology)
-    }
-
-    /// Test that different pathfinders produce different behavior in payments
-    #[tokio::test]
-    async fn test_pathfinder_affects_payment_behavior() {
-        let channels = create_simulated_channels(3, 1_000_000_000);
-        let (shutdown_trigger, shutdown_listener) = triggered::trigger();
-        let sim_graph = Arc::new(Mutex::new(
-            SimGraph::new(
-                channels.clone(),
-                TaskTracker::new(),
-                Vec::new(),
-                HashMap::new(), // Empty custom records
-                (shutdown_trigger.clone(), shutdown_listener.clone()),
-            )
-            .unwrap(),
-        ));
-        let routing_graph =
-            Arc::new(populate_network_graph(channels.clone(), Arc::new(SystemClock {})).unwrap());
-
-        // Create nodes with different pathfinders
-        let nodes_default = ln_node_from_graph(
-            sim_graph.clone(),
-            routing_graph.clone(),
-            SystemClock {},
-            simln_lib::sim_node::DefaultPathFinder,
-        )
-        .await;
-
-        let nodes_fail = ln_node_from_graph(
-            sim_graph.clone(),
-            routing_graph.clone(),
-            SystemClock {},
-            AlwaysFailPathFinder,
-        )
-        .await;
-
-        // Both should create the same structure
-        assert_eq!(nodes_default.len(), nodes_fail.len());
-    }
 }

--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -338,6 +338,16 @@ impl SimulatedChannel {
         }
     }
 
+    /// Gets the public key of node 1 in the channel.
+    pub fn get_node_1_pubkey(&self) -> PublicKey {
+        self.node_1.policy.pubkey
+    }
+
+    /// Gets the public key of node 2 in the channel.
+    pub fn get_node_2_pubkey(&self) -> PublicKey {
+        self.node_2.policy.pubkey
+    }
+
     /// Validates that a simulated channel has distinct node pairs and valid routing policies.
     fn validate(&self) -> Result<(), SimulationError> {
         if self.node_1.policy.pubkey == self.node_2.policy.pubkey {
@@ -1121,7 +1131,7 @@ where
     P: PathFinder + 'static,
 {
     let mut nodes: HashMap<PublicKey, Arc<Mutex<dyn LightningNode>>> = HashMap::new();
-    
+
     for pk in graph.lock().await.nodes.keys() {
         nodes.insert(
             *node.0,

--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -526,6 +526,12 @@ pub trait PathFinder: Send + Sync + Clone {
 #[derive(Clone)]
 pub struct DefaultPathFinder;
 
+impl Default for DefaultPathFinder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DefaultPathFinder {
     pub fn new() -> Self {
         Self

--- a/simln-lib/src/sim_node.rs
+++ b/simln-lib/src/sim_node.rs
@@ -537,21 +537,33 @@ pub trait PathFinder: Send + Sync + Clone {
 }
 
 /// The default pathfinding implementation that uses LDK's built-in pathfinding algorithm.
-#[derive(Clone)]
 pub struct DefaultPathFinder {
-    scorer: Arc<Mutex<ProbabilisticScorer<Arc<LdkNetworkGraph>, Arc<WrappedLog>>>>,
+    scorer: Mutex<ProbabilisticScorer<Arc<LdkNetworkGraph>, Arc<WrappedLog>>>,
     network_graph: Arc<LdkNetworkGraph>,
 }
 
 impl DefaultPathFinder {
     pub fn new(network_graph: Arc<LdkNetworkGraph>) -> Self {
         Self {
-            scorer: Arc::new(Mutex::new(ProbabilisticScorer::new(
+            scorer: Mutex::new(ProbabilisticScorer::new(
                 ProbabilisticScoringDecayParameters::default(),
                 network_graph.clone(),
                 Arc::new(WrappedLog {}),
-            ))),
+            )),
             network_graph,
+        }
+    }
+}
+
+impl Clone for DefaultPathFinder {
+    fn clone(&self) -> Self {
+        DefaultPathFinder {
+            scorer: Mutex::new(ProbabilisticScorer::new(
+                ProbabilisticScoringDecayParameters::default(),
+                self.network_graph.clone(),
+                Arc::new(WrappedLog {}),
+            )),
+            network_graph: self.network_graph.clone(),
         }
     }
 }

--- a/simln-lib/src/test_utils.rs
+++ b/simln-lib/src/test_utils.rs
@@ -250,3 +250,35 @@ pub fn create_activity(
         amount_msat: ValueOrRange::Value(amount_msat),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_activity() {
+        let (_source_sk, source_pk) = get_random_keypair();
+        let (_dest_sk, dest_pk) = get_random_keypair();
+
+        let source_info = NodeInfo {
+            pubkey: source_pk,
+            alias: "source".to_string(),
+            features: Features::empty(),
+        };
+
+        let dest_info = NodeInfo {
+            pubkey: dest_pk,
+            alias: "destination".to_string(),
+            features: Features::empty(),
+        };
+
+        let activity = create_activity(source_info.clone(), dest_info.clone(), 1000);
+
+        assert_eq!(activity.source.pubkey, source_info.pubkey);
+        assert_eq!(activity.destination.pubkey, dest_info.pubkey);
+        match activity.amount_msat {
+            ValueOrRange::Value(amount) => assert_eq!(amount, 1000),
+            ValueOrRange::Range(_, _) => panic!("Expected Value variant, got Range"),
+        }
+    }
+}


### PR DESCRIPTION
This PR builds upon the work done here #273 

This PR introduces a new `PathFinder` trait which allows for more flexible pathfinding. Instead of being locked into the LDK pathfinding algorithm, custom pathfinding algorithms can be swapped in. A `DefaultPathFinder` has been provided to maintain backwards compatibility.